### PR TITLE
feat: Add “onEnd” callbacks to `useEffectListener`

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,12 @@ const board = EffectsBoardWrapper(BoardComponent, {
 
 3. Dependencies (`array`) — an array of variables your callback depends upon (similar to [React’s `useCallback` hook][useCallback]).
 
+4. _(optional)_ On-End Callback (`function`) — a function to run when the effect
+   ends (as defined by the effects `duration`).
+
+5. _(optional)_ On-End Dependencies (`array`) — an array of variables your
+   on-end callback depends on.
+
 ##### Usage
 
 Within your board component or child components, use the `useEffectListener`

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ const board = EffectsBoardWrapper(BoardComponent, {
 3. Dependencies (`array`) — an array of variables your callback depends upon (similar to [React’s `useCallback` hook][useCallback]).
 
 4. _(optional)_ On-End Callback (`function`) — a function to run when the effect
-   ends (as defined by the effects `duration`).
+   ends (as defined by the effect’s `duration`).
 
 5. _(optional)_ On-End Dependencies (`array`) — an array of variables your
    on-end callback depends on.

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -44,16 +44,16 @@ describe('Plugin API', () => {
     api.dumb();
     api.rollDie(6);
     expect(api.timeline.getQueue()).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'alert', duration: 0.2 },
-      { t: 0.2, type: 'dumb', duration: 0 },
-      { t: 0.2, type: 'rollDie', payload: { roll: 6 }, duration: 0 },
-      { t: 0.2, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'alert', endT: 0.2 },
+      { t: 0.2, type: 'dumb', endT: 0.2 },
+      { t: 0.2, type: 'rollDie', payload: { roll: 6 }, endT: 0.2 },
+      { t: 0.2, type: 'effects:end', endT: 0.2 },
     ]);
     api.timeline.clear();
     expect(api.timeline.getQueue()).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'effects:end', endT: 0 },
     ]);
   });
 

--- a/src/plugin.test.ts
+++ b/src/plugin.test.ts
@@ -45,9 +45,9 @@ describe('Plugin API', () => {
     api.rollDie(6);
     expect(api.timeline.getQueue()).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'alert' },
-      { t: 0.2, type: 'dumb' },
-      { t: 0.2, type: 'rollDie', payload: { roll: 6 } },
+      { t: 0, type: 'alert', duration: 0.2 },
+      { t: 0.2, type: 'dumb', duration: 0 },
+      { t: 0.2, type: 'rollDie', payload: { roll: 6 }, duration: 0 },
       { t: 0.2, type: 'effects:end' },
     ]);
     api.timeline.clear();

--- a/src/react/components.tsx
+++ b/src/react/components.tsx
@@ -105,8 +105,7 @@ function EffectsProvider<
     let ended = false;
     for (let i = 0; i < activeQueue.current.length; i++) {
       const effect = activeQueue.current[i];
-      if (!effect.duration) continue;
-      if (effect.t + effect.duration > elapsedT) {
+      if (effect.endT > elapsedT) {
         newActiveQueue.push(effect);
         continue;
       }

--- a/src/react/components.tsx
+++ b/src/react/components.tsx
@@ -67,7 +67,6 @@ function EffectsProvider<
   props: P;
   opts?: EffectsOpts;
 }) {
-  type NaiveEffect = { t: number; type: string; payload?: any };
   const { effects } = props.plugins as { effects?: { data: Data } };
   const id = effects && effects.data.id;
   const duration = (effects && effects.data.duration) || 0;
@@ -88,7 +87,7 @@ function EffectsProvider<
     // Loop through the effects queue, emitting any effects whose time has come.
     let i = 0;
     for (i = 0; i < q.length; i++) {
-      const effect = q[i] as NaiveEffect;
+      const effect = q[i];
       if (!effect || effect.t > elapsedT) break;
       emitter.emit(effect.type, effect.payload);
     }
@@ -141,7 +140,7 @@ function EffectsProvider<
    */
   const flush = useCallback(() => {
     for (let i = 0; i < queue.current.length; i++) {
-      const effect = queue.current[i] as NaiveEffect;
+      const effect = queue.current[i];
       emitter.emit(effect.type, effect.payload);
     }
     clear();

--- a/src/react/components.tsx
+++ b/src/react/components.tsx
@@ -3,7 +3,7 @@ import useRafLoop from 'react-use/lib/useRafLoop';
 import useUpdate from 'react-use/lib/useUpdate';
 import mitt from 'mitt';
 import type { BoardProps } from 'boardgame.io/react';
-import type { EffectsPluginConfig, Data, Queue } from '../types';
+import type { Data, Queue } from '../types';
 import { EffectsContext, EffectsQueueContext } from './contexts';
 
 /**
@@ -49,9 +49,8 @@ function EffectsProvider<
   props: P;
   opts?: EffectsOpts;
 }) {
-  type E = EffectsPluginConfig['effects'];
   type NaiveEffect = { t: number; type: string; payload?: any };
-  const { effects } = props.plugins as { effects?: { data: Data<E> } };
+  const { effects } = props.plugins as { effects?: { data: Data } };
   const id = effects && effects.data.id;
   const duration = (effects && effects.data.duration) || 0;
   const bgioStateT: number = updateStateAfterEffects ? duration : 0;
@@ -59,10 +58,10 @@ function EffectsProvider<
   const [emitter] = useState(() => mitt());
   const [startT, setStartT] = useState(0);
   const [bgioProps, setBgioProps] = useState(props);
-  const queue = useRef<Queue<E>>([]);
+  const queue = useRef<Queue>([]);
   const rerender = useUpdate();
   const setQueue = useCallback(
-    (newQueue: Queue<E>) => {
+    (newQueue: Queue) => {
       queue.current = newQueue;
       rerender();
     },

--- a/src/react/contexts.ts
+++ b/src/react/contexts.ts
@@ -1,7 +1,10 @@
 import { createContext } from 'react';
 import type { Emitter } from 'mitt';
 
-export const EffectsContext = createContext<Emitter | null>(null);
+export const EffectsContext = createContext<{
+  emitter: Emitter | null;
+  endEmitter: Emitter | null;
+}>({ emitter: null, endEmitter: null });
 
 export const EffectsQueueContext = createContext<
   { clear: () => void; flush: () => void; size: number } | undefined

--- a/src/react/hooks/useEffectListener.ts
+++ b/src/react/hooks/useEffectListener.ts
@@ -1,37 +1,84 @@
+import type { Emitter, Handler, WildcardHandler } from 'mitt';
 import { useCallback, useContext, useEffect } from 'react';
 import { EffectsContext } from '../contexts';
 import type { EffectsPluginConfig, ListenerArgs } from '../../types';
 import { hookErrorMessage } from './utils';
+
+type AnyHandler = Handler | WildcardHandler;
+type NaiveArgs = [
+  string,
+  AnyHandler,
+  React.DependencyList,
+  AnyHandler?,
+  React.DependencyList?
+];
+
+/**
+ * No-op fallback for `useCallback` that is never actually called.
+ */
+// istanbul ignore next
+function noop() {}
+
+/**
+ * Subscribe to a Mitt instance with automatic callback memoization & clean-up.
+ * @param  emitter - The Mitt instance to subscribe to.
+ * @param  effectType - Name of the effect to listen for. '*' listens to any.
+ * @param  handler - Function to call when the event is emitted.
+ * @param  dependencies - Array of variables the handler depends on.
+ */
+function useMittSubscription(
+  emitter: Emitter,
+  effectType: string,
+  handler: AnyHandler | undefined,
+  dependencies: React.DependencyList | undefined = []
+) {
+  const hasHandler = !!handler;
+  const memoizedHandler = useCallback(handler || noop, dependencies);
+
+  useEffect(() => {
+    if (!hasHandler) return;
+
+    let cleanup: void | (() => void);
+
+    const cb = (...args: any[]) => {
+      if (typeof cleanup === 'function') cleanup();
+      cleanup = (memoizedHandler as any)(...args);
+    };
+
+    emitter.on(effectType, cb);
+
+    return () => {
+      emitter.off(effectType, cb);
+      if (typeof cleanup === 'function') cleanup();
+    };
+  }, [effectType, emitter, memoizedHandler, hasHandler]);
+}
 
 /**
  * Subscribe to events emitted by the effects state.
  * @param effectType - Name of the effect to listen for. '*' listens to any.
  * @param callback - Function to call when the event is emitted.
  * @param dependencyArray - Array of variables the callback function depends on.
+ * @param onEndCallback - Function to call when the effect ends.
+ * @param onEndDependencyArray - Array of variables onEndCallback depends on.
  */
 export function useEffectListener<C extends EffectsPluginConfig>(
   ...args: ListenerArgs<C['effects']>
 ) {
-  if (!emitter) throw new Error(hookErrorMessage('useEffectListener'));
-  const [effectType, cb, deps] = args;
   const { emitter, endEmitter } = useContext(EffectsContext);
+  const [effectType, cb, deps, onEndCb, onEndDeps] = args as NaiveArgs;
+
+  if (!emitter || !endEmitter)
+    throw new Error(hookErrorMessage('useEffectListener'));
   if (!deps)
     throw new TypeError(
       'useEffectListener must receive a dependency list as its third argument.'
     );
-  const callback = useCallback(cb, deps);
+  if (onEndCb && !onEndDeps)
+    throw new TypeError(
+      'useEffectListener must receive a dependency list as its fifth argument when using an onEffectEnd callback.'
+    );
 
-  useEffect(() => {
-    let cleanup: void | (() => void);
-
-    emitter.on(effectType as string, (...args) => {
-      if (typeof cleanup === 'function') cleanup();
-      cleanup = callback(...args);
-    });
-
-    return () => {
-      emitter.off(effectType as string, callback as (...args: any) => any);
-      if (typeof cleanup === 'function') cleanup();
-    };
-  }, [emitter, effectType, callback]);
+  useMittSubscription(emitter, effectType, cb, deps);
+  useMittSubscription(endEmitter, effectType, onEndCb, onEndDeps);
 }

--- a/src/react/hooks/useEffectListener.ts
+++ b/src/react/hooks/useEffectListener.ts
@@ -12,9 +12,9 @@ import { hookErrorMessage } from './utils';
 export function useEffectListener<C extends EffectsPluginConfig>(
   ...args: ListenerArgs<C['effects']>
 ) {
-  const emitter = useContext(EffectsContext);
   if (!emitter) throw new Error(hookErrorMessage('useEffectListener'));
   const [effectType, cb, deps] = args;
+  const { emitter, endEmitter } = useContext(EffectsContext);
   if (!deps)
     throw new TypeError(
       'useEffectListener must receive a dependency list as its third argument.'

--- a/src/react/index.test.tsx
+++ b/src/react/index.test.tsx
@@ -235,61 +235,106 @@ test('Speed option changes effect timing', async () => {
 });
 
 describe('useEffectListener', () => {
-  test('useEffectListener callback can return a clean-up callback', async () => {
+  test('callback can return a clean-up callback', async () => {
     enum ListenerState {
-      'bar' = 'bar',
-      'foo' = 'foo',
-      'baz' = 'baz',
+      'Initial' = 'bar',
+      'OnEffect' = 'foo',
+      'AfterEffect' = 'baz',
     }
     const clear = jest.fn((to: NodeJS.Timeout) => clearTimeout(to));
     const ComponentWithEffects = () => {
-      const [state, setState] = useState(ListenerState.bar);
+      const [state, setState] = useState(ListenerState.Initial);
       useEffectListener<typeof config>(
         'shortEffect',
         () => {
-          setState(ListenerState.foo);
+          setState(ListenerState.OnEffect);
           const to = setTimeout(() => {
-            setState(ListenerState.baz);
-          }, 100);
+            setState(ListenerState.AfterEffect);
+          }, 150);
           return () => clear(to);
         },
-        [state]
+        []
       );
-      useEffectListener<typeof config>('shortEffect', () => {}, []);
       return <p data-testid="CWE">{state}</p>;
     };
     const App = Client<G>({
       game: (game as unknown) as Game<G>,
       debug: false,
-      board: EffectsBoardWrapper(({ G, moves }: BoardProps<G>) => {
+      board: EffectsBoardWrapper(({ G, moves }: BoardProps<G>) => (
+        <main>
+          {(!G.val || G.val === GVal.repeatEffects) && <ComponentWithEffects />}
+          <p data-testid="G-val">{G.val}</p>
+          <button onClick={() => moves.simple()}>Simple Move</button>
+          <button onClick={() => moves.repeatEffects()}>Repeat Effects</button>
+        </main>
+      )),
+    });
+
+    render(<App />);
+    expect(screen.getByTestId('CWE')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Repeat Effects'));
+    await waitFor(() => screen.getByText(GVal.repeatEffects));
+    await waitFor(() => screen.getByText(ListenerState.OnEffect));
+    expect(clear).toHaveBeenCalledTimes(0);
+    await waitFor(() => screen.getByText(ListenerState.AfterEffect));
+    // Called once when cleanup executed for repeated effect.
+    expect(clear).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('Simple Move'));
+    await waitFor(() => screen.getByText(GVal.simple));
+    expect(screen.queryByTestId('CWE')).not.toBeInTheDocument();
+    // Called again on component unmount.
+    expect(clear).toHaveBeenCalledTimes(2);
+  });
+
+  test('can receive an onEnd callback', async () => {
+    enum ListenerState {
+      'Initial' = 'Initial',
+      'OnStart' = 'OnStart',
+      'OnEnd' = 'OnEnd',
+    }
+    const mock = jest.fn();
+    const App = Client({
+      game: (game as unknown) as Game<G>,
+      debug: false,
+      board: EffectsBoardWrapper(({ moves }) => {
+        const [val, setVal] = useState(ListenerState.Initial);
+        useEffectListener<typeof config>(
+          'shortEffect',
+          (val: string) => {
+            mock(val, ListenerState.OnStart);
+            setVal(ListenerState.OnStart);
+          },
+          [],
+          (val: string) => {
+            mock(val, ListenerState.OnEnd);
+            setVal(ListenerState.OnEnd);
+          },
+          []
+        );
         return (
-          <main>
-            {(!G.val || G.val === GVal.repeatEffects) && (
-              <ComponentWithEffects />
-            )}
-            <p data-testid="G-val">{G.val}</p>
-            <button onClick={() => moves.simple()}>Simple Move</button>
-            <button onClick={() => moves.repeatEffects()}>
-              Repeat Effects
-            </button>
-          </main>
+          <div>
+            <h1>{val}</h1>
+            <button onClick={() => moves.wEffects()}>Move</button>
+          </div>
         );
       }),
     });
 
     render(<App />);
-    expect(screen.getByTestId('CWE')).toBeInTheDocument();
-    fireEvent.click(screen.getByText('Repeat Effects'));
-    await waitFor(() => screen.getByText(GVal.repeatEffects));
-    await waitFor(() => screen.getByText(ListenerState.foo));
-    await waitFor(() => screen.getByText(ListenerState.baz));
-    fireEvent.click(screen.getByText('Simple Move'));
-    await waitFor(() => screen.getByText(GVal.simple));
-    expect(screen.queryByTestId('CWE')).not.toBeInTheDocument();
-    expect(clear).toHaveBeenCalledTimes(3);
+    screen.getByText(ListenerState.Initial);
+
+    fireEvent.click(screen.getByText('Move'));
+    await waitFor(() => screen.getByText(ListenerState.OnStart));
+    expect(mock).toHaveBeenCalledTimes(1);
+    expect(mock).toHaveBeenLastCalledWith('2', ListenerState.OnStart);
+    await waitFor(() => screen.getByText(ListenerState.OnEnd));
+    expect(mock).toHaveBeenCalledTimes(2);
+    expect(mock).toHaveBeenLastCalledWith('2', ListenerState.OnEnd);
   });
 
-  test('useEffectListener throws if used outside of EffectsBoardWrapper', () => {
+  test('throws if used outside of EffectsBoardWrapper', () => {
     const App = () => {
       useEffectListener('*', () => {}, []);
       return <div />;
@@ -299,7 +344,7 @@ describe('useEffectListener', () => {
     );
   });
 
-  test('useEffectListener throws if not passed a dependency list', () => {
+  test('throws if not passed a dependency list', () => {
     const board = EffectsBoardWrapper(() => {
       useEffectListener(
         '*',
@@ -311,6 +356,23 @@ describe('useEffectListener', () => {
     const App = Client({ game: (game as unknown) as Game<G>, board });
     expect(() => render(<App />)).toThrow(
       'useEffectListener must receive a dependency list as its third argument.'
+    );
+  });
+
+  test('throws if not passed an onEnd dependency list', () => {
+    const board = EffectsBoardWrapper(() => {
+      useEffectListener(
+        '*',
+        () => {},
+        [],
+        () => {},
+        (undefined as unknown) as React.DependencyList
+      );
+      return <div />;
+    });
+    const App = Client({ game: (game as unknown) as Game<G>, board });
+    expect(() => render(<App />)).toThrow(
+      'useEffectListener must receive a dependency list as its fifth argument when using an onEffectEnd callback.'
     );
   });
 });

--- a/src/timeline.test.ts
+++ b/src/timeline.test.ts
@@ -17,9 +17,9 @@ describe('#add', () => {
     t.add({ type: 'test' });
     const queue = t.getQueue();
     expect(queue).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test', duration: 0 },
-      { t: 0, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'test', endT: 0 },
+      { t: 0, type: 'effects:end', endT: 0 },
     ]);
   });
 
@@ -28,11 +28,11 @@ describe('#add', () => {
     t.add({ type: 'bar' }, '>', 5);
     const queue = t.getQueue();
     expect(queue).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test', duration: 0 },
-      { t: 0, type: 'foo', duration: 5 },
-      { t: 5, type: 'bar', duration: 5 },
-      { t: 10, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'test', endT: 0 },
+      { t: 0, type: 'foo', endT: 5 },
+      { t: 5, type: 'bar', endT: 10 },
+      { t: 10, type: 'effects:end', endT: 10 },
     ]);
   });
 
@@ -41,13 +41,13 @@ describe('#add', () => {
     t.add({ type: 'bam' }, '>+0.5', 1);
     const queue = t.getQueue();
     expect(queue).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test', duration: 0 },
-      { t: 0, type: 'foo', duration: 5 },
-      { t: 5, type: 'bar', duration: 5 },
-      { t: 9, type: 'baz', duration: 1 },
-      { t: 10.5, type: 'bam', duration: 1 },
-      { t: 11.5, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'test', endT: 0 },
+      { t: 0, type: 'foo', endT: 5 },
+      { t: 5, type: 'bar', endT: 10 },
+      { t: 9, type: 'baz', endT: 10 },
+      { t: 10.5, type: 'bam', endT: 11.5 },
+      { t: 11.5, type: 'effects:end', endT: 11.5 },
     ]);
   });
 
@@ -56,15 +56,15 @@ describe('#add', () => {
     t.add({ type: 'bup' }, '<+0.5', 2);
     const queue = t.getQueue();
     expect(queue).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test', duration: 0 },
-      { t: 0, type: 'foo', duration: 5 },
-      { t: 5, type: 'bar', duration: 5 },
-      { t: 9, type: 'baz', duration: 1 },
-      { t: 9.5, type: 'buq', duration: 2 },
-      { t: 10.5, type: 'bam', duration: 1 },
-      { t: 11, type: 'bup', duration: 2 },
-      { t: 13, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'test', endT: 0 },
+      { t: 0, type: 'foo', endT: 5 },
+      { t: 5, type: 'bar', endT: 10 },
+      { t: 9, type: 'baz', endT: 10 },
+      { t: 9.5, type: 'buq', endT: 11.5 },
+      { t: 10.5, type: 'bam', endT: 11.5 },
+      { t: 11, type: 'bup', endT: 13 },
+      { t: 13, type: 'effects:end', endT: 13 },
     ]);
   });
 
@@ -72,16 +72,16 @@ describe('#add', () => {
     t.add({ type: 'fixed' }, 4);
     const queue = t.getQueue();
     expect(queue).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test', duration: 0 },
-      { t: 0, type: 'foo', duration: 5 },
-      { t: 4, type: 'fixed', duration: 0 },
-      { t: 5, type: 'bar', duration: 5 },
-      { t: 9, type: 'baz', duration: 1 },
-      { t: 9.5, type: 'buq', duration: 2 },
-      { t: 10.5, type: 'bam', duration: 1 },
-      { t: 11, type: 'bup', duration: 2 },
-      { t: 13, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'test', endT: 0 },
+      { t: 0, type: 'foo', endT: 5 },
+      { t: 4, type: 'fixed', endT: 4 },
+      { t: 5, type: 'bar', endT: 10 },
+      { t: 9, type: 'baz', endT: 10 },
+      { t: 9.5, type: 'buq', endT: 11.5 },
+      { t: 10.5, type: 'bam', endT: 11.5 },
+      { t: 11, type: 'bup', endT: 13 },
+      { t: 13, type: 'effects:end', endT: 13 },
     ]);
   });
 
@@ -89,17 +89,17 @@ describe('#add', () => {
     t.add({ type: 'ins' }, '^10', 1);
     const queue = t.getQueue();
     expect(queue).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test', duration: 0 },
-      { t: 0, type: 'foo', duration: 5 },
-      { t: 4, type: 'fixed', duration: 0 },
-      { t: 5, type: 'bar', duration: 5 },
-      { t: 9, type: 'baz', duration: 1 },
-      { t: 9.5, type: 'buq', duration: 2 },
-      { t: 10, type: 'ins', duration: 1 },
-      { t: 11.5, type: 'bam', duration: 1 },
-      { t: 12, type: 'bup', duration: 2 },
-      { t: 14, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'test', endT: 0 },
+      { t: 0, type: 'foo', endT: 5 },
+      { t: 4, type: 'fixed', endT: 4 },
+      { t: 5, type: 'bar', endT: 10 },
+      { t: 9, type: 'baz', endT: 10 },
+      { t: 9.5, type: 'buq', endT: 11.5 },
+      { t: 10, type: 'ins', endT: 11 },
+      { t: 11.5, type: 'bam', endT: 12.5 },
+      { t: 12, type: 'bup', endT: 14 },
+      { t: 14, type: 'effects:end', endT: 14 },
     ]);
   });
 
@@ -107,18 +107,18 @@ describe('#add', () => {
     t.add({ type: 'uns' }, '^11->0.5', 1);
     const queue = t.getQueue();
     expect(queue).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test', duration: 0 },
-      { t: 0, type: 'foo', duration: 5 },
-      { t: 4, type: 'fixed', duration: 0 },
-      { t: 5, type: 'bar', duration: 5 },
-      { t: 9, type: 'baz', duration: 1 },
-      { t: 9.5, type: 'buq', duration: 2 },
-      { t: 10, type: 'ins', duration: 1 },
-      { t: 11, type: 'uns', duration: 1 },
-      { t: 12, type: 'bam', duration: 1 },
-      { t: 12.5, type: 'bup', duration: 2 },
-      { t: 14.5, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'test', endT: 0 },
+      { t: 0, type: 'foo', endT: 5 },
+      { t: 4, type: 'fixed', endT: 4 },
+      { t: 5, type: 'bar', endT: 10 },
+      { t: 9, type: 'baz', endT: 10 },
+      { t: 9.5, type: 'buq', endT: 11.5 },
+      { t: 10, type: 'ins', endT: 11 },
+      { t: 11, type: 'uns', endT: 12 },
+      { t: 12, type: 'bam', endT: 13 },
+      { t: 12.5, type: 'bup', endT: 14.5 },
+      { t: 14.5, type: 'effects:end', endT: 14.5 },
     ]);
   });
 
@@ -127,10 +127,10 @@ describe('#add', () => {
     t.add({ type: 'nu' }, '^', 1);
     t.add({ type: 'bu' });
     expect(t.getQueue()).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'nu', duration: 1 },
-      { t: 1, type: 'bu', duration: 0 },
-      { t: 1, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'nu', endT: 1 },
+      { t: 1, type: 'bu', endT: 1 },
+      { t: 1, type: 'effects:end', endT: 1 },
     ]);
   });
 
@@ -139,10 +139,10 @@ describe('#add', () => {
     t.add({ type: 'e' }, '<', 1);
     t.add({ type: 'mc' });
     expect(t.getQueue()).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'e', duration: 1 },
-      { t: 1, type: 'mc', duration: 0 },
-      { t: 1, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'e', endT: 1 },
+      { t: 1, type: 'mc', endT: 1 },
+      { t: 1, type: 'effects:end', endT: 1 },
     ]);
   });
 
@@ -194,21 +194,21 @@ describe('#clear', () => {
     t.add({ type: 'a' }, '>', 1);
     t.add({ type: 'b' }, '>', 1);
     expect(t.getQueue()).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'a', duration: 1 },
-      { t: 1, type: 'b', duration: 1 },
-      { t: 2, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'a', endT: 1 },
+      { t: 1, type: 'b', endT: 2 },
+      { t: 2, type: 'effects:end', endT: 2 },
     ]);
     t.clear();
     expect(t.getQueue()).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'effects:end', endT: 0 },
     ]);
     t.add({ type: 'a' }, '>', 1);
     expect(t.getQueue()).toEqual([
-      { t: 0, type: 'effects:start' },
-      { t: 0, type: 'a', duration: 1 },
-      { t: 1, type: 'effects:end' },
+      { t: 0, type: 'effects:start', endT: 0 },
+      { t: 0, type: 'a', endT: 1 },
+      { t: 1, type: 'effects:end', endT: 1 },
     ]);
   });
 });

--- a/src/timeline.test.ts
+++ b/src/timeline.test.ts
@@ -1,4 +1,5 @@
 import { Timeline } from './timeline';
+import type { Effect } from './types';
 
 describe('construction', () => {
   test('creates an instance with expected methods', () => {
@@ -17,7 +18,7 @@ describe('#add', () => {
     const queue = t.getQueue();
     expect(queue).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test' },
+      { t: 0, type: 'test', duration: 0 },
       { t: 0, type: 'effects:end' },
     ]);
   });
@@ -28,9 +29,9 @@ describe('#add', () => {
     const queue = t.getQueue();
     expect(queue).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test' },
-      { t: 0, type: 'foo' },
-      { t: 5, type: 'bar' },
+      { t: 0, type: 'test', duration: 0 },
+      { t: 0, type: 'foo', duration: 5 },
+      { t: 5, type: 'bar', duration: 5 },
       { t: 10, type: 'effects:end' },
     ]);
   });
@@ -41,11 +42,11 @@ describe('#add', () => {
     const queue = t.getQueue();
     expect(queue).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test' },
-      { t: 0, type: 'foo' },
-      { t: 5, type: 'bar' },
-      { t: 9, type: 'baz' },
-      { t: 10.5, type: 'bam' },
+      { t: 0, type: 'test', duration: 0 },
+      { t: 0, type: 'foo', duration: 5 },
+      { t: 5, type: 'bar', duration: 5 },
+      { t: 9, type: 'baz', duration: 1 },
+      { t: 10.5, type: 'bam', duration: 1 },
       { t: 11.5, type: 'effects:end' },
     ]);
   });
@@ -56,13 +57,13 @@ describe('#add', () => {
     const queue = t.getQueue();
     expect(queue).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test' },
-      { t: 0, type: 'foo' },
-      { t: 5, type: 'bar' },
-      { t: 9, type: 'baz' },
-      { t: 9.5, type: 'buq' },
-      { t: 10.5, type: 'bam' },
-      { t: 11, type: 'bup' },
+      { t: 0, type: 'test', duration: 0 },
+      { t: 0, type: 'foo', duration: 5 },
+      { t: 5, type: 'bar', duration: 5 },
+      { t: 9, type: 'baz', duration: 1 },
+      { t: 9.5, type: 'buq', duration: 2 },
+      { t: 10.5, type: 'bam', duration: 1 },
+      { t: 11, type: 'bup', duration: 2 },
       { t: 13, type: 'effects:end' },
     ]);
   });
@@ -72,14 +73,14 @@ describe('#add', () => {
     const queue = t.getQueue();
     expect(queue).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test' },
-      { t: 0, type: 'foo' },
-      { t: 4, type: 'fixed' },
-      { t: 5, type: 'bar' },
-      { t: 9, type: 'baz' },
-      { t: 9.5, type: 'buq' },
-      { t: 10.5, type: 'bam' },
-      { t: 11, type: 'bup' },
+      { t: 0, type: 'test', duration: 0 },
+      { t: 0, type: 'foo', duration: 5 },
+      { t: 4, type: 'fixed', duration: 0 },
+      { t: 5, type: 'bar', duration: 5 },
+      { t: 9, type: 'baz', duration: 1 },
+      { t: 9.5, type: 'buq', duration: 2 },
+      { t: 10.5, type: 'bam', duration: 1 },
+      { t: 11, type: 'bup', duration: 2 },
       { t: 13, type: 'effects:end' },
     ]);
   });
@@ -89,15 +90,15 @@ describe('#add', () => {
     const queue = t.getQueue();
     expect(queue).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test' },
-      { t: 0, type: 'foo' },
-      { t: 4, type: 'fixed' },
-      { t: 5, type: 'bar' },
-      { t: 9, type: 'baz' },
-      { t: 9.5, type: 'buq' },
-      { t: 10, type: 'ins' },
-      { t: 11.5, type: 'bam' },
-      { t: 12, type: 'bup' },
+      { t: 0, type: 'test', duration: 0 },
+      { t: 0, type: 'foo', duration: 5 },
+      { t: 4, type: 'fixed', duration: 0 },
+      { t: 5, type: 'bar', duration: 5 },
+      { t: 9, type: 'baz', duration: 1 },
+      { t: 9.5, type: 'buq', duration: 2 },
+      { t: 10, type: 'ins', duration: 1 },
+      { t: 11.5, type: 'bam', duration: 1 },
+      { t: 12, type: 'bup', duration: 2 },
       { t: 14, type: 'effects:end' },
     ]);
   });
@@ -107,16 +108,16 @@ describe('#add', () => {
     const queue = t.getQueue();
     expect(queue).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'test' },
-      { t: 0, type: 'foo' },
-      { t: 4, type: 'fixed' },
-      { t: 5, type: 'bar' },
-      { t: 9, type: 'baz' },
-      { t: 9.5, type: 'buq' },
-      { t: 10, type: 'ins' },
-      { t: 11, type: 'uns' },
-      { t: 12, type: 'bam' },
-      { t: 12.5, type: 'bup' },
+      { t: 0, type: 'test', duration: 0 },
+      { t: 0, type: 'foo', duration: 5 },
+      { t: 4, type: 'fixed', duration: 0 },
+      { t: 5, type: 'bar', duration: 5 },
+      { t: 9, type: 'baz', duration: 1 },
+      { t: 9.5, type: 'buq', duration: 2 },
+      { t: 10, type: 'ins', duration: 1 },
+      { t: 11, type: 'uns', duration: 1 },
+      { t: 12, type: 'bam', duration: 1 },
+      { t: 12.5, type: 'bup', duration: 2 },
       { t: 14.5, type: 'effects:end' },
     ]);
   });
@@ -127,8 +128,8 @@ describe('#add', () => {
     t.add({ type: 'bu' });
     expect(t.getQueue()).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'nu' },
-      { t: 1, type: 'bu' },
+      { t: 0, type: 'nu', duration: 1 },
+      { t: 1, type: 'bu', duration: 0 },
       { t: 1, type: 'effects:end' },
     ]);
   });
@@ -139,8 +140,8 @@ describe('#add', () => {
     t.add({ type: 'mc' });
     expect(t.getQueue()).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'e' },
-      { t: 1, type: 'mc' },
+      { t: 0, type: 'e', duration: 1 },
+      { t: 1, type: 'mc', duration: 0 },
       { t: 1, type: 'effects:end' },
     ]);
   });
@@ -163,7 +164,7 @@ describe('#isEmpty', () => {
   });
 
   test('returns false for a timeline with entries', () => {
-    t.add({});
+    t.add({} as Effect);
     expect(t.isEmpty()).toBe(false);
   });
 
@@ -181,8 +182,8 @@ describe('#duration', () => {
   });
 
   test('returns the total duration', () => {
-    t.add({}, '>', 1);
-    t.add({}, '>', 1);
+    t.add({} as Effect, '>', 1);
+    t.add({} as Effect, '>', 1);
     expect(t.duration()).toBe(2);
   });
 });
@@ -194,8 +195,8 @@ describe('#clear', () => {
     t.add({ type: 'b' }, '>', 1);
     expect(t.getQueue()).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'a' },
-      { t: 1, type: 'b' },
+      { t: 0, type: 'a', duration: 1 },
+      { t: 1, type: 'b', duration: 1 },
       { t: 2, type: 'effects:end' },
     ]);
     t.clear();
@@ -206,7 +207,7 @@ describe('#clear', () => {
     t.add({ type: 'a' }, '>', 1);
     expect(t.getQueue()).toEqual([
       { t: 0, type: 'effects:start' },
-      { t: 0, type: 'a' },
+      { t: 0, type: 'a', duration: 1 },
       { t: 1, type: 'effects:end' },
     ]);
   });

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -121,14 +121,19 @@ export class Timeline {
    *         Each effect has a property `t` specifying its time on the timeline.
    */
   getQueue(): Queue {
-    let queue: Queue = [{ t: 0, type: 'effects:start' }];
+    let queue: Queue = [{ t: 0, endT: 0, type: 'effects:start' }];
     this.keys().forEach((t) => {
       const effects = this._keyframes.get(t)!;
       effects.forEach((effect) => {
-        queue.push({ t, ...effect });
+        const { duration, ...rest } = effect;
+        queue.push({ t, endT: t + duration, ...rest });
       });
     });
-    queue.push({ t: this._duration, type: 'effects:end' });
+    queue.push({
+      t: this._duration,
+      endT: this._duration,
+      type: 'effects:end',
+    });
     return queue;
   }
 

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -1,4 +1,4 @@
-import type { Queue, Effect, EffectsPluginConfig, TimingParams } from './types';
+import type { Queue, Effect, TimingParams } from './types';
 
 const float = '(?:\\d*\\.?\\d+|\\d+\\.?\\d*)?';
 const insertPositionRE = RegExp(`^\\^(${float})(->(${float})?)?$`);
@@ -14,9 +14,9 @@ const parseInsertPosition = (position: string) => {
  * Timeline that allows adding data and returning an ordered queue of
  * data by timestamp.
  */
-export class Timeline<E extends EffectsPluginConfig['effects']> {
+export class Timeline {
   private _last: null | number;
-  private _keyframes: Map<number, Effect<E>[]>;
+  private _keyframes: Map<number, Array<Effect & { duration: number }>>;
   private _duration: number;
 
   constructor() {
@@ -76,7 +76,7 @@ export class Timeline<E extends EffectsPluginConfig['effects']> {
    * @param duration Duration of the effect when played back.
    */
   add(
-    effect: Effect<E>,
+    effect: Effect,
     position: TimingParams[0] = this._duration,
     duration: TimingParams[1] = 0
   ): void {
@@ -105,7 +105,7 @@ export class Timeline<E extends EffectsPluginConfig['effects']> {
     }
 
     const entries = this._keyframes.get(position) || [];
-    this._keyframes.set(position, [...entries, effect]);
+    this._keyframes.set(position, [...entries, { duration, ...effect }]);
 
     if (this._last === null || position > this._last) {
       this._last = position;
@@ -120,12 +120,12 @@ export class Timeline<E extends EffectsPluginConfig['effects']> {
    * @return Sorted array of effects.
    *         Each effect has a property `t` specifying its time on the timeline.
    */
-  getQueue(): Queue<E> {
-    let queue: Queue<E> = [{ t: 0, type: 'effects:start' }];
+  getQueue(): Queue {
+    let queue: Queue = [{ t: 0, type: 'effects:start' }];
     this.keys().forEach((t) => {
       const effects = this._keyframes.get(t)!;
-      effects.forEach((data) => {
-        queue.push({ t, ...(data as object) } as Queue<E>[number]);
+      effects.forEach((effect) => {
+        queue.push({ t, ...effect });
       });
     });
     queue.push({ t: this._duration, type: 'effects:end' });

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,41 +43,34 @@ export interface EffectsPluginConfig {
 type BuiltinEffect = 'effects:start' | 'effects:end';
 
 /**
- * Type describing the possible effect objects produced by an EffectsPlugin.
- * @param E - A map of EffectConfig interfaces to derive the shapes from.
+ * Type describing the effect objects produced by the EffectsPlugin.
  */
-export type Effect<E extends EffectsMap> =
-  | U.IntersectOf<
-      O.UnionOf<
-        {
-          [K in keyof E]: E[K] extends EffectWithCreate
-            ? {
-                type: K;
-                payload: EffectPayload<E[K]>;
-              }
-            : E[K] extends EffectWithoutCreate
-            ? { type: K }
-            : never;
-        }
-      >
-    >
-  | { type: BuiltinEffect };
+export interface Effect {
+  type: string;
+  payload?: any;
+}
+
+/**
+ * Type describing an effect when persisted to the game state.
+ */
+interface PersistedEffect extends Effect {
+  t: number;
+  duration?: number;
+}
 
 /**
  * Type describing the queue of effects persisted to game state.
- * @param E - A map of EffectConfig interfaces to derive the data from.
  */
-export type Queue<E extends EffectsMap> = Array<Effect<E> & { t: number }>;
+export type Queue = PersistedEffect[];
 
 /**
  * Type describing the EffectsPlugin data object.
- * @param E - A map of EffectConfig interfaces to derive the data from.
  */
-export type Data<E extends EffectsMap> = {
+export interface Data {
   id: string;
   duration: number;
-  queue: Queue<E>;
-};
+  queue: Queue;
+}
 
 type Duration = number;
 type Position = number | string;
@@ -88,7 +81,7 @@ export type TimingParams = [Position, Duration];
  * @param E - A tuple of EffectConfig interfaces to derive the API from.
  */
 export type API<E extends EffectsMap> = {
-  timeline: Timeline<E>;
+  timeline: Timeline;
 } & U.IntersectOf<
   O.UnionOf<
     {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ export interface Effect {
  */
 interface PersistedEffect extends Effect {
   t: number;
-  duration?: number;
+  endT: number;
 }
 
 /**


### PR DESCRIPTION
Following discussion in #85, this PR adds support for passing an optional “onEnd” callback to `useEffectListener`. Effect durations are now used to compute a end time as well as the effect’s start time, allowing the effect emitter to emit end events.

Basic usage looks something like:

```js
import { useEffectListener } from 'bgio-effects/react';

function Component() {
  const onStart = (effectPayload) => {};
  const onEnd = (effectPayload) => {};
  useEffectListener('effectName', onStart, [], onEnd, []);
  return <div/>;
}
```

This allows component code not to worry about the duration of an effect if that is preferred. (Ultimately this is still an inversion of control that is not necessarily a good idea — clients/front-end code should ideally own timing etc. — but for now this may still be ergonomic for this use case.)