### PR TITLE
feat(react): Add `useEffectState` utility hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,9 +339,6 @@ when an effect fires.
 
 1. Effect Type (`string`) — the effect you want to observe state for.
 
-2. Duration (`number`) — the number of seconds the effect is “active” for when
-   its state updates.
-
 ##### Returns
 
 A `[state, isActive]` tuple.
@@ -356,7 +353,7 @@ A `[state, isActive]` tuple.
 import { useEffectState } from 'bgio-effects/react';
 
 function Component() {
-  const [roll, isRolling] = useEffectState('rollDie', 1);
+  const [roll, isRolling] = useEffectState('rollDie');
   const className = isRolling ? 'animated' : 'static';
   return <div className={className}>{roll}</div>;
 }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ useEffectListener('explode', () => {
 
 ## Usage
 
+<!-- TOC START min:3 max:4 link:true asterisk:false update:true -->
+- [Plugin](#plugin)
+  - [Configuration](#configuration)
+  - [Adding the plugin to your game](#adding-the-plugin-to-your-game)
+  - [Sequencing effects](#sequencing-effects)
+- [React](#react)
+  - [`EffectsBoardWrapper`](#effectsboardwrapper)
+  - [`useEffectListener`](#useeffectlistener)
+  - [`useEffectState`](#useeffectstate)
+  - [`useEffectQueue`](#useeffectqueue)
+  - [Timing precision](#timing-precision)
+<!-- TOC END -->
+
 ### Plugin
 
 #### Configuration
@@ -307,6 +320,39 @@ function DiceComponent() {
   );
 
   return <div className={animate ? 'animated' : 'static'} />;
+}
+```
+
+#### `useEffectState`
+
+The `useEffectState` hook provides an abstraction around `useEffectListener`
+for cases where you don’t need to call other imperative code
+when an effect fires.
+
+##### Parameters
+
+1. Effect Type (`string`) — the effect you want to observe state for.
+
+2. Duration (`number`) — the number of seconds the effect is “active” for when
+   its state updates.
+
+##### Returns
+
+A `[state, isActive]` tuple.
+
+- `state`: The latest value for this effect type.
+  This will be `undefined` until the effect fires.
+- `isActive`: A boolean indicating whether the effect is currently active.
+
+##### Usage
+
+```js
+import { useEffectState } from 'bgio-effects/react';
+
+function Component() {
+  const [roll, isRolling] = useEffectState('rollDie', 1);
+  const className = isRolling ? 'animated' : 'static';
+  return <div className={className}>{roll}</div>;
 }
 ```
 

--- a/src/react/hooks/useEffectState.ts
+++ b/src/react/hooks/useEffectState.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import type { EffectsPluginConfig, EffectState } from '../../types';
+import { useEffectListener } from './useEffectListener';
+
+type EffectStateReturn<
+  C extends EffectsPluginConfig,
+  K extends keyof C['effects']
+> = readonly [EffectState<C['effects'][K]> | undefined, boolean];
+
+/**
+ * Subscribe to the latest value of a particular effect.
+ * This hook is sugar around `useEffectListener`, `useState`, and `setTimeout`.
+ * @param effectType - Name of the effect to subscribe to.
+ * @param duration - Duration in seconds to flag this effect as “active” for.
+ * @return Tuple of `[effectState: any, isActive: boolean]`. Will be `[undefined, false]` on initial render.
+ */
+export function useEffectState<
+  C extends EffectsPluginConfig,
+  K extends keyof C['effects']
+>(effectType: K, duration = 0, _config?: C): EffectStateReturn<C, K> {
+  const [state, setState] = useState<EffectState<C['effects'][K]>>();
+  const [isActive, setIsActive] = useState(false);
+
+  useEffectListener(
+    effectType as any,
+    (payload: any) => {
+      setState(payload);
+      setIsActive(true);
+      const timeout = setTimeout(() => setIsActive(false), duration * 1000);
+      return () => clearTimeout(timeout);
+    },
+    [duration]
+  );
+
+  return [state, isActive];
+}

--- a/src/react/hooks/useEffectState.ts
+++ b/src/react/hooks/useEffectState.ts
@@ -9,15 +9,16 @@ type EffectStateReturn<
 
 /**
  * Subscribe to the latest value of a particular effect.
- * This hook is sugar around `useEffectListener`, `useState`, and `setTimeout`.
+ * This hook is sugar around `useEffectListener` and `useState`.
  * @param effectType - Name of the effect to subscribe to.
- * @param duration - Duration in seconds to flag this effect as “active” for.
- * @return Tuple of `[effectState: any, isActive: boolean]`. Will be `[undefined, false]` on initial render.
+ * @return - Tuple of `[effectState: any, isActive: boolean]`.
+ * Will be `[undefined, false]` on initial render.
+ * `isActive` is true for the length of the effect’s duration.
  */
 export function useEffectState<
   C extends EffectsPluginConfig,
   K extends keyof C['effects']
->(effectType: K, duration = 0, _config?: C): EffectStateReturn<C, K> {
+>(effectType: K, _config?: C): EffectStateReturn<C, K> {
   const [state, setState] = useState<EffectState<C['effects'][K]>>();
   const [isActive, setIsActive] = useState(false);
 
@@ -26,10 +27,10 @@ export function useEffectState<
     (payload: any) => {
       setState(payload);
       setIsActive(true);
-      const timeout = setTimeout(() => setIsActive(false), duration * 1000);
-      return () => clearTimeout(timeout);
     },
-    [duration]
+    [],
+    () => setIsActive(false),
+    []
   );
 
   return [state, isActive];

--- a/src/react/index.test.tsx
+++ b/src/react/index.test.tsx
@@ -405,7 +405,7 @@ describe('useEffectState', () => {
 
   test('useEffectState provides state', async () => {
     const board = EffectsBoardWrapper(({ moves }: BoardProps<G>) => {
-      const [state, isActive] = useEffectState('longEffect', 1);
+      const [state, isActive] = useEffectState('longEffect', config);
       return (
         <main>
           <button onClick={() => moves.wEffects()}>Move With Effects</button>
@@ -432,6 +432,6 @@ describe('useEffectState', () => {
 
     await waitFor(() => screen.getByText('false'));
     const t = performance.now() - t1;
-    expect(t).toBeGreaterThan(900);
+    expect(t).toBeGreaterThan(800);
   });
 });

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -1,3 +1,4 @@
 export { EffectsBoardWrapper } from './components';
 export { useEffectListener } from './hooks/useEffectListener';
 export { useEffectQueue } from './hooks/useEffectQueue';
+export { useEffectState } from './hooks/useEffectState';

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,13 @@ interface EffectWithoutCreate extends EffectConfig {
 type EffectPayload<E extends EffectWithCreate> = F.Return<O.At<E, 'create'>>;
 
 /**
+ * Extract the payload that results from any single effect.
+ */
+export type EffectState<E extends EffectConfig> = E extends EffectWithCreate
+  ? EffectPayload<E>
+  : unknown;
+
+/**
  * Map of effect name strings to EffectConfig interfaces.
  */
 type EffectsMap = Record<string, EffectConfig>;


### PR DESCRIPTION
Following on from #85, this PR adds a utility hook `useEffectState`, which wraps `useEffectListener` to handle a fairly common use case.

#### Usage

```js
import { useEffectState } from 'bgio-effects/react';

function Component() {
  const [roll, isRolling] = useEffectState('rollDie');
  const className = isRolling ? 'animated' : 'static';
  return <div className={className}>{roll}</div>;
}
```