### PR TITLE
Add useLatestPropsOnEffect hook

### DIFF
--- a/src/react/components.tsx
+++ b/src/react/components.tsx
@@ -6,7 +6,11 @@ import type { Emitter } from 'mitt';
 import type { BoardProps } from 'boardgame.io/react';
 import type { Data, Queue } from '../types';
 import type { InternalEffectShape } from './types';
-import { EffectsContext, EffectsQueueContext } from './contexts';
+import {
+  EffectsContext,
+  EffectsPropsContext,
+  EffectsQueueContext,
+} from './contexts';
 
 /**
  * Configuration options that can be passed to EffectsBoardWrapper.
@@ -210,7 +214,9 @@ function EffectsProvider<
       <EffectsQueueContext.Provider
         value={{ clear, flush, size: queue.current.length }}
       >
-        <Board {...(bgioProps as P)} />
+        <EffectsPropsContext.Provider value={bgioProps}>
+          <Board {...(bgioProps as P)} />
+        </EffectsPropsContext.Provider>
       </EffectsQueueContext.Provider>
     </EffectsContext.Provider>
   );

--- a/src/react/contexts.ts
+++ b/src/react/contexts.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react';
 import type { Emitter } from 'mitt';
+import type { BoardProps } from 'boardgame.io/react';
 
 export const EffectsContext = createContext<{
   emitter: Emitter | null;
@@ -9,3 +10,7 @@ export const EffectsContext = createContext<{
 export const EffectsQueueContext = createContext<
   { clear: () => void; flush: () => void; size: number } | undefined
 >(undefined);
+
+export const EffectsPropsContext = createContext<BoardProps | undefined>(
+  undefined
+);

--- a/src/react/hooks/useBoardProps.ts
+++ b/src/react/hooks/useBoardProps.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { EffectsPropsContext } from '../contexts';
+import { hookErrorMessage } from './utils';
+
+/**
+ * Get current board props as maintained by the effects plugin
+ * @return - The boardgame.io props including G and ctx
+ */
+export function useBoardProps() {
+  const ctx = useContext(EffectsPropsContext);
+  if (!ctx) throw new Error(hookErrorMessage('useBoardProps'));
+  return ctx;
+}

--- a/src/react/hooks/useLatestPropsOnEffect.ts
+++ b/src/react/hooks/useLatestPropsOnEffect.ts
@@ -2,6 +2,12 @@ import type { BoardProps } from 'boardgame.io/react';
 import { useEffect, useState } from 'react';
 import { useEffectListener } from './useEffectListener';
 import { useBoardProps } from './useBoardProps';
+import type { BuiltinEffect, EffectsPluginConfig } from '../../types';
+
+type EffectType<C extends EffectsPluginConfig> =
+  | BuiltinEffect
+  | '*'
+  | keyof C['effects'];
 
 /**
  * Returns the latest board props when one or more effect
@@ -9,7 +15,10 @@ import { useBoardProps } from './useBoardProps';
  * @param effectTypes - List of effects to subscribe to.
  * @return The boardgame.io props including G and ctx
  */
-export function useLatestPropsOnEffect(...effectTypes: Array<string>) {
+export function useLatestPropsOnEffect<
+  G extends any = any,
+  C extends EffectsPluginConfig = EffectsPluginConfig
+>(...effectTypes: EffectType<C>[]): BoardProps<G> {
   const boardProps = useBoardProps();
   const [props, setProps] = useState(boardProps);
 

--- a/src/react/hooks/useLatestPropsOnEffect.ts
+++ b/src/react/hooks/useLatestPropsOnEffect.ts
@@ -1,5 +1,5 @@
 import type { BoardProps } from 'boardgame.io/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useEffectListener } from './useEffectListener';
 import { useBoardProps } from './useBoardProps';
 import type { BuiltinEffect, EffectsPluginConfig } from '../../types';
@@ -21,15 +21,26 @@ export function useLatestPropsOnEffect<
 >(...effectTypes: EffectType<C>[]): BoardProps<G> {
   const boardProps = useBoardProps();
   const [props, setProps] = useState(boardProps);
+  const effects = useRef(effectTypes);
+
+  if (
+    effectTypes.length !== effects.current.length ||
+    !effects.current.every((v, i) => v === effectTypes[i])
+  ) {
+    effects.current = effectTypes;
+  }
 
   useEffectListener(
     '*',
     (effectName: string, _payload: any, boardProps: BoardProps) => {
-      if (effectTypes.includes(effectName) || effectTypes.includes('*')) {
+      if (
+        effects.current.includes(effectName) ||
+        effects.current.includes('*')
+      ) {
         setProps(boardProps);
       }
     },
-    [effectTypes]
+    [effects]
   );
 
   useEffect(() => {

--- a/src/react/hooks/useLatestPropsOnEffect.ts
+++ b/src/react/hooks/useLatestPropsOnEffect.ts
@@ -1,0 +1,31 @@
+import type { BoardProps } from 'boardgame.io/react';
+import { useEffect, useState } from 'react';
+import { useEffectListener } from './useEffectListener';
+import { useBoardProps } from './useBoardProps';
+
+/**
+ * Returns the latest board props when one or more effect
+ * is triggered. Essentially sugar around `useEffectListener`.
+ * @param effectTypes - List of effects to subscribe to.
+ * @return The boardgame.io props including G and ctx
+ */
+export function useLatestPropsOnEffect(...effectTypes: Array<string>) {
+  const boardProps = useBoardProps();
+  const [props, setProps] = useState(boardProps);
+
+  useEffectListener(
+    '*',
+    (effectName: string, _payload: any, boardProps: BoardProps) => {
+      if (effectTypes.includes(effectName) || effectTypes.includes('*')) {
+        setProps(boardProps);
+      }
+    },
+    [effectTypes]
+  );
+
+  useEffect(() => {
+    setProps(boardProps);
+  }, [boardProps]);
+
+  return props;
+}

--- a/src/react/index.test.tsx
+++ b/src/react/index.test.tsx
@@ -507,8 +507,11 @@ describe('useLatestPropsOnEffect', () => {
   test('provides effect state', async () => {
     const board = EffectsBoardWrapper(
       ({ moves }: BoardProps<G>) => {
-        const { G } = useLatestPropsOnEffect('longEffect');
         const [, isActive] = useEffectState('longEffect', undefined, config);
+        const effects = isActive
+          ? ['longEffect', 'shortEffect']
+          : ['longEffect'];
+        const { G } = useLatestPropsOnEffect(...effects);
         return (
           <main>
             <button onClick={() => moves.wEffects()}>Move With Effects</button>

--- a/src/react/index.test.tsx
+++ b/src/react/index.test.tsx
@@ -8,6 +8,7 @@ import {
   useEffectListener,
   useEffectQueue,
   useEffectState,
+  useLatestPropsOnEffect,
 } from '.';
 import { EffectsPlugin } from '../plugin';
 import { EffectsCtxMixin } from '..';
@@ -489,5 +490,49 @@ describe('useEffectState', () => {
     render(<App />);
 
     expect(screen.getByTestId('state')).toHaveTextContent('init');
+  });
+});
+
+describe('useLatestPropsOnEffect', () => {
+  test('throws if used outside of EffectsBoardWrapper', () => {
+    const App = () => {
+      const {} = useLatestPropsOnEffect('*');
+      return <div />;
+    };
+    expect(() => render(<App />)).toThrow(
+      'useBoardProps must be called inside the effects context provider.'
+    );
+  });
+
+  test('provides effect state', async () => {
+    const board = EffectsBoardWrapper(
+      ({ moves }: BoardProps<G>) => {
+        const { G } = useLatestPropsOnEffect('longEffect');
+        const [, isActive] = useEffectState('longEffect', undefined, config);
+        return (
+          <main>
+            <button onClick={() => moves.wEffects()}>Move With Effects</button>
+            <p data-testid="state">{G.val}</p>
+            <p data-testid="isActive">{JSON.stringify(isActive)}</p>
+          </main>
+        );
+      },
+      { updateStateAfterEffects: true }
+    );
+
+    const App = Client({
+      game: (game as unknown) as Game<G>,
+      board,
+      debug: false,
+    });
+
+    render(<App />);
+
+    expect(screen.getByTestId('state')).toBeEmptyDOMElement();
+
+    fireEvent.click(screen.getByText('Move With Effects'));
+    await waitFor(() => screen.getByText('true'));
+
+    expect(screen.getByTestId('state')).toHaveTextContent(GVal.wEffects);
   });
 });

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -2,3 +2,4 @@ export { EffectsBoardWrapper } from './components';
 export { useEffectListener } from './hooks/useEffectListener';
 export { useEffectQueue } from './hooks/useEffectQueue';
 export { useEffectState } from './hooks/useEffectState';
+export { useLatestPropsOnEffect } from './hooks/useLatestPropsOnEffect';


### PR DESCRIPTION
As discussed in #111, this creates a new context to store and get the board props and adds a hook to get the latest version of board props when certain effects are triggered. Particularly useful when using `updateStateAfterEffects: true`.

The hook takes a list of effect names and returns the updated state. Essentially some sugar around `useEffectListener`. It takes care of the special case of `*` to update on any event.