### PR TITLE
feat: Rewrite client-side effects emitter & add plain JS support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
         node: [12.x, 14.x, 16.x]
         # Test with oldest and newest supported boardgame.io versions
-        bgio: [0.39.16, latest]
+        bgio: [0.42.0, latest]
         # Test with React 16 and React 17
         react: [^16, ^17]
     steps:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 This package provides a structured approach to triggering ephemeral “effects”
 in game code that can be consumed from state on the client. It provides a game
-plugin and a React board wrapper that emits client-side events for your effects.
+plugin and a client-side extension that emits events for your effects.
 
 
 ## Installation
@@ -28,12 +28,18 @@ function move(G, ctx) {
 }
 ```
 
-Listen for effects from your board component:
+Listen for effects on the client:
 
 ```js
-useEffectListener('explode', () => {
+const onExplode = () => {
   // render explosion/play sound/etc.
-});
+};
+
+// With the plain JS emitter
+emitter.on('explode', onExplode);
+
+// With the React hook
+useEffectListener('explode', onExplode, []);
 ```
 
 
@@ -44,13 +50,18 @@ useEffectListener('explode', () => {
   - [Configuration](#configuration)
   - [Adding the plugin to your game](#adding-the-plugin-to-your-game)
   - [Sequencing effects](#sequencing-effects)
-- [React](#react)
+- [With a plain JS client](#with-a-plain-js-client)
+  - [`EffectsEmitter`](#effectsemitter)
+  - [`EffectsEmitter#on()`](#effectsemitteron)
+  - [`EffectsEmitter#state`](#effectsemitterstate)
+  - [Queue API](#queue-api)
+- [With a React client](#with-a-react-client)
   - [`EffectsBoardWrapper`](#effectsboardwrapper)
   - [`useEffectListener`](#useeffectlistener)
   - [`useEffectState`](#useeffectstate)
   - [`useLatestPropsOnEffect`](#uselatestpropsoneffect)
   - [`useEffectQueue`](#useeffectqueue)
-  - [Timing precision](#timing-precision)
+- [Timing precision](#timing-precision)
 <!-- TOC END -->
 
 ### Plugin
@@ -214,7 +225,160 @@ E('<');     // add E, aligning it with start of last effect
 D              A     C    B+E
 ```
 
-### React
+---
+
+### With a plain JS client
+
+#### `EffectsEmitter`
+
+`EffectsEmitter` wraps a boardgame.io client, returning an API that allows you
+to subscribe to specific effects as well as the latest boardgame.io state.
+
+To create an emitter instance, pass your boardgame.io client to
+`EffectsEmitter`:
+
+```js
+import { Client } from 'boardgame.io/client';
+import { EffectsEmitter } from 'bgio-effects/client';
+
+const client = Client({ /* game, etc. */ });
+const emitter = EffectsEmitter(client);
+client.start();
+```
+
+##### Options
+
+In addition to passing `EffectsEmitter` the boardgame.io client, you can pass
+an options object to configure the effects behaviour.
+
+```js
+const emitter = EffectsEmitter(client, {
+  // Delay updating emitter.state until after the
+  // last effect has been triggered.
+  // Default: false
+  updateStateAfterEffects: true,
+
+  // Global control of the speed of effect playback.
+  // Default: 1
+  speed: 1,
+});
+```
+
+#### `EffectsEmitter#on()`
+
+##### Parameters
+
+1. Effect Type (`string`) — the effect you want to listen for.
+
+2. Callback (`function`) — the function to run when the effect is fired.
+
+4. _(optional)_ On-End Callback (`function`) — a function to run when the effect
+   ends (as defined by the effect’s `duration`).
+
+##### Returns
+
+An unsubscribe callback.
+
+##### Usage
+
+Call your emitter instance’s `on` method to listen for effect events.
+
+```js
+// Subscribe to the “effectName” effect.
+const unsubscribe = emitter.on('effectName', (effectPayload, bgioState) => {});
+
+// When you want to stop listening for this effect,
+// call the returned unsubscribe callback.
+unsubscribe();
+```
+
+`effectPayload` will be the data returned by your `create` function or
+`undefined` for effects without a `create` function.
+
+`bgioState` will be the latest state passed by boardgame.io. This is particularly useful when using the `updateStateAfterEffects` option to get early access to the new global state.
+
+##### Special Events
+
+You can listen for _all_ effects using the special `'*'` wildcard. In this case,
+your callback receives both the effect name and payload:
+
+```js
+emitter.on('*', (effectName, effectPayload, boardProps) => {});
+```
+
+Two other special events will also always be fired:
+
+- `'effects:start'` will fire before any other effects.
+
+- `'effects:end'` will fire after all the effects in the queue have completed.
+
+##### Example
+
+```js
+const dice = document.querySelector('#dice');
+
+const onRollStart = () => dice.classList.add('animated');
+const onRollEnd = () =>  dice.classList.remove('animated');
+
+emitter.on('rollDie', onRollStart, onRollEnd);
+```
+
+#### `EffectsEmitter#state`
+
+An emitter instance has a `state` property which is a store you can subscribe
+to that mirrors boardgame.io’s state. The only difference between subscribing
+to `EffectsEmitter#state` and subscribing directly to the boardgame.io client
+is that `EffectsEmitter#state` delays updating if you set the
+`updateStateAfterEffects` option to `true` when creating the emitter.
+
+##### Usage
+
+Subscribe to state updates:
+
+```js
+// Instead of client.subscribe((state) => {}), use this:
+const unsubscribe = emitter.state.subscribe((state) => {});
+```
+
+Or get the current state:
+
+```js
+// Instead of client.getState(), use this:
+const state = emitter.state.get();
+```
+
+#### Queue API
+
+`EffectsEmitter` instances also expose an API to allow direct control of the
+effect queue if necessary.
+
+- `EffectsEmitter#clear()`: Cancel any currently queued effects from being fired.
+- `EffectsEmitter#flush()`: Immediately trigger any currently queued effects.
+- `EffectsEmitter#size`: A subscribable store containing the number of effects
+  currently queued.
+
+##### Usage
+
+```js
+const clearButton = document.querySelector('button#clear');
+clearButton.addEventListener('click', () => {
+  emitter.clear();
+});
+
+const flushButton = document.querySelector('button#flush');
+flushButton.addEventListener('click', () => {
+  emitter.flush();
+});
+
+const queueSizeEl = document.querySelector('#queue-size');
+emitter.size.subscribe((size) => {
+  queueSizeEl.textContent = 'Queue size: ' + size;
+});
+```
+
+---
+
+### With a React client
 
 The provided React component wrapper and hooks allow you to consume your effects
 as events, emitting them over time if you used the effect sequencing features.
@@ -301,7 +465,7 @@ Two other special events will also always be fired:
 
 - `'effects:start'` will fire before any other effects.
 
-- `'effects:end'` will fire after all the effects in the queue.
+- `'effects:end'` will fire after all the effects in the queue have completed.
 
 ##### Example
 
@@ -426,7 +590,7 @@ function Component() {
 - `flush()`: Immediately trigger any currently queued effects.
 - `size`: The number of effects currently queued.
 
-#### Timing precision
+### Timing precision
 
 This library is not designed with highly precise timing and animation
 synchronisation in mind. Effects are emitted from a `requestAnimationFrame`

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bgio-effects/client",
+  "private": true,
+  "main": "../dist/emitter/index.js",
+  "types": "../dist/emitter/index.d.ts"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -479,6 +479,7 @@
       "version": "7.12.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
       "integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -1514,11 +1515,6 @@
         "pretty-format": "^27.0.0"
       }
     },
-    "@types/js-cookie": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.7.tgz",
-      "integrity": "sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA=="
-    },
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
@@ -1862,11 +1858,6 @@
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
-    },
-    "@xobotyi/scrollbar-width": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
-      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
     },
     "JSONStream": {
       "version": "1.3.5",
@@ -2865,14 +2856,6 @@
         }
       }
     },
-    "copy-to-clipboard": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
-      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
-      "requires": {
-        "toggle-selection": "^1.0.6"
-      }
-    },
     "core-js-pure": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.3.tgz",
@@ -2942,24 +2925,6 @@
         "source-map-resolve": "^0.6.0"
       }
     },
-    "css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
-      "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
-      }
-    },
-    "css-tree": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
-      "requires": {
-        "mdn-data": "2.0.14",
-        "source-map": "^0.6.1"
-      }
-    },
     "css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -2992,7 +2957,8 @@
     "csstype": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
-      "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
+      "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==",
+      "dev": true
     },
     "cz-conventional-changelog": {
       "version": "3.3.0",
@@ -3425,14 +3391,6 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "error-stack-parser": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
-      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
-      "requires": {
-        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -3969,7 +3927,8 @@
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.2.7",
@@ -3995,16 +3954,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fast-shallow-equal": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
-      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
-    },
-    "fastest-stable-stringify": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-2.0.2.tgz",
-      "integrity": "sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q=="
     },
     "fastq": {
       "version": "1.13.0",
@@ -4555,11 +4504,6 @@
       "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
       "dev": true
     },
-    "hyphenate-style-name": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4648,14 +4592,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
-    },
-    "inline-style-prefixer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.1.tgz",
-      "integrity": "sha512-AsqazZ8KcRzJ9YPN1wMH2aNM7lkWQ8tSPrW5uDk1ziYwiAPWSZnUsC7lfZq+BDqLqz0B4Pho5wscWcJzVvRzDQ==",
-      "requires": {
-        "css-in-js-utils": "^2.0.0"
-      }
     },
     "inquirer": {
       "version": "6.5.2",
@@ -4946,11 +4882,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -5996,11 +5927,6 @@
         }
       }
     },
-    "js-cookie": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
-      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -6409,11 +6335,6 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
-    "mdn-data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
-    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -6650,21 +6571,6 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
-    },
-    "nano-css": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.4.tgz",
-      "integrity": "sha512-wfcviJB6NOxDIDfr7RFn/GlaN7I/Bhe4d39ZRCJ3xvZX60LVe2qZ+rDqM49nm4YT81gAjzS+ZklhKP/Gnfnubg==",
-      "requires": {
-        "css-tree": "^1.1.2",
-        "csstype": "^3.0.6",
-        "fastest-stable-stringify": "^2.0.2",
-        "inline-style-prefixer": "^6.0.0",
-        "rtl-css-js": "^1.14.0",
-        "sourcemap-codec": "^1.4.8",
-        "stacktrace-js": "^2.0.2",
-        "stylis": "^4.0.6"
-      }
     },
     "nanoid": {
       "version": "3.1.30",
@@ -7263,32 +7169,6 @@
       "integrity": "sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==",
       "dev": true
     },
-    "react-universal-interface": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
-      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
-    },
-    "react-use": {
-      "version": "17.3.2",
-      "resolved": "https://registry.npmjs.org/react-use/-/react-use-17.3.2.tgz",
-      "integrity": "sha512-bj7OD0/1wL03KyWmzFXAFe425zziuTf7q8olwCYBfOeFHY1qfO1FAMjROQLsLZYwG4Rx63xAfb7XAbBrJsZmEw==",
-      "requires": {
-        "@types/js-cookie": "^2.2.6",
-        "@xobotyi/scrollbar-width": "^1.9.5",
-        "copy-to-clipboard": "^3.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "fast-shallow-equal": "^1.0.0",
-        "js-cookie": "^2.2.1",
-        "nano-css": "^5.3.1",
-        "react-universal-interface": "^0.6.2",
-        "resize-observer-polyfill": "^1.5.1",
-        "screenfull": "^5.1.0",
-        "set-harmonic-interval": "^1.0.1",
-        "throttle-debounce": "^3.0.1",
-        "ts-easing": "^0.2.0",
-        "tslib": "^2.1.0"
-      }
-    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -7435,7 +7315,8 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
     },
     "regexp.prototype.flags": {
       "version": "1.3.1",
@@ -7458,11 +7339,6 @@
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
-    },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "resolve": {
       "version": "1.20.0",
@@ -7546,14 +7422,6 @@
         "glob": "^7.1.3"
       }
     },
-    "rtl-css-js": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.15.0.tgz",
-      "integrity": "sha512-99Cu4wNNIhrI10xxUaABHsdDqzalrSRTie4GeCmbGVuehm4oj+fIy8fTzB+16pmKe8Bv9rl+hxIBez6KxExTew==",
-      "requires": {
-        "@babel/runtime": "^7.1.2"
-      }
-    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -7617,11 +7485,6 @@
         "object-assign": "^4.1.1"
       }
     },
-    "screenfull": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
-      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="
-    },
     "semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -7630,11 +7493,6 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
-    },
-    "set-harmonic-interval": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
-      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -7799,7 +7657,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.6.0",
@@ -7820,11 +7679,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -7882,14 +7736,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "stack-generator": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
-      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
-      "requires": {
-        "stackframe": "^1.1.1"
-      }
-    },
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -7905,37 +7751,6 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
-      }
-    },
-    "stackframe": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
-    },
-    "stacktrace-gps": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
-      "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
-      "requires": {
-        "source-map": "0.5.6",
-        "stackframe": "^1.1.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
-        }
-      }
-    },
-    "stacktrace-js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
-      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
-      "requires": {
-        "error-stack-parser": "^2.0.6",
-        "stack-generator": "^2.0.5",
-        "stacktrace-gps": "^3.0.4"
       }
     },
     "standard-version": {
@@ -8179,11 +7994,6 @@
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
     },
-    "stylis": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
-      "integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
-    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -8277,11 +8087,6 @@
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
     },
-    "throttle-debounce": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
-      "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg=="
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -8327,11 +8132,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "toggle-selection": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
-      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
-    },
     "toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -8364,11 +8164,6 @@
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
-    "ts-easing": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
-      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
-    },
     "ts-jest": {
       "version": "27.1.2",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.2.tgz",
@@ -8389,11 +8184,6 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
       "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
-    },
-    "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "tsscmp": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "ts-toolbelt": "^9"
   },
   "peerDependencies": {
-    "boardgame.io": ">=0.39.16",
+    "boardgame.io": ">=0.42.0",
     "react": "^16 || ^17"
   },
   "config": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
+    "client/**/*",
     "dist/**/*",
     "plugin/**/*",
     "react/**/*"

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
   },
   "dependencies": {
     "mitt": "^3.0.0",
-    "react-use": "^17.2.3",
     "ts-toolbelt": "^9"
   },
   "peerDependencies": {

--- a/src/emitter/emitter.test.ts
+++ b/src/emitter/emitter.test.ts
@@ -176,8 +176,8 @@ describe('EffectsEmitter', () => {
   });
 
   describe('#size', () => {
-    test('it returns the number of effects in the queue', async () => {
-      await waitFor(() => emitter.size.get() === 0);
+    test('it returns the number of effects in the queue', () => {
+      expect(emitter.size.get()).toBe(0);
       client.moves.wEffects();
       expect(emitter.size.get()).toBe(4);
     });
@@ -186,9 +186,11 @@ describe('EffectsEmitter', () => {
       const listener = jest.fn();
       emitter.size.subscribe(listener);
       expect(listener).toHaveBeenCalledTimes(1);
-      expect(listener).toHaveBeenLastCalledWith(2);
+      expect(listener).toHaveBeenLastCalledWith(0);
+      client.moves.simple();
       await waitFor(() => emitter.size.get() === 0);
-      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenCalledTimes(3);
+      expect(listener).toHaveBeenCalledWith(2);
       expect(listener).toHaveBeenLastCalledWith(0);
     });
   });

--- a/src/emitter/emitter.test.ts
+++ b/src/emitter/emitter.test.ts
@@ -71,7 +71,7 @@ describe('EffectsEmitter', () => {
   let emitter: ReturnType<typeof EffectsEmitter>;
 
   beforeEach(() => {
-    client = Client({ game });
+    client = Client({ game: game as unknown as Game });
     emitter = EffectsEmitter(client);
     client.start();
   });

--- a/src/emitter/emitter.test.ts
+++ b/src/emitter/emitter.test.ts
@@ -184,7 +184,7 @@ describe('EffectsEmitter', () => {
 
     test('a subscriber receives the latest queue size', async () => {
       const listener = jest.fn();
-      emitter.size.subscribe(listener);
+      const unsubscribe = emitter.size.subscribe(listener);
       expect(listener).toHaveBeenCalledTimes(1);
       expect(listener).toHaveBeenLastCalledWith(0);
       client.moves.simple();
@@ -192,6 +192,7 @@ describe('EffectsEmitter', () => {
       expect(listener).toHaveBeenCalledTimes(3);
       expect(listener).toHaveBeenCalledWith(2);
       expect(listener).toHaveBeenLastCalledWith(0);
+      unsubscribe();
     });
   });
 
@@ -216,13 +217,14 @@ describe('EffectsEmitter', () => {
 
     test('a subscriber receives the latest state', async () => {
       const listener = jest.fn();
-      emitter.state.subscribe(listener);
+      const unsubscribe = emitter.state.subscribe(listener);
       expect(listener).toHaveBeenCalledTimes(1);
       expect(listener).toHaveBeenLastCalledWith(client.getState());
       client.moves.simple();
       await waitFor(() => emitter.size.get() === 0);
       expect(listener).toHaveBeenCalledTimes(2);
       expect(listener).toHaveBeenLastCalledWith(client.getState());
+      unsubscribe();
     });
   });
 

--- a/src/emitter/emitter.test.ts
+++ b/src/emitter/emitter.test.ts
@@ -1,0 +1,215 @@
+import type { Ctx, Game } from 'boardgame.io';
+import { Client } from 'boardgame.io/client';
+import type { EffectsCtxMixin } from '..';
+import { EffectsPlugin } from '../plugin';
+import { EffectsEmitter } from '.';
+
+const config = {
+  effects: {
+    longEffect: {
+      duration: 0.8,
+      create: (str: string) => str,
+    },
+    shortEffect: {
+      duration: 0.1,
+      create: (str: string) => str,
+    },
+  },
+} as const;
+
+enum GVal {
+  'simple' = 'simple',
+  'wEffects' = 'wEffects',
+  'repeatEffects' = 'repeatEffects',
+}
+
+type G = { val?: GVal };
+
+const game: Game<G, Ctx & EffectsCtxMixin<typeof config>> = {
+  plugins: [EffectsPlugin(config)],
+  moves: {
+    simple(G) {
+      G.val = GVal.simple;
+    },
+    wEffects(G, ctx) {
+      G.val = GVal.wEffects;
+      ctx.effects.longEffect('1');
+      ctx.effects.shortEffect('2');
+    },
+    repeatEffects(G, ctx) {
+      G.val = GVal.repeatEffects;
+      ctx.effects.shortEffect('2');
+      ctx.effects.shortEffect('2');
+    },
+  },
+};
+
+/**
+ * Run a callback on an interval and resolve when it returns `true`.
+ * @param condition Callback that should eventually return `true`.
+ * @param interval Interval on which to test the condition callback (in ms).
+ * @param timeout How long to wait for the condition to be `true` before rejecting (in ms).
+ */
+const waitFor = (condition: () => boolean, interval = 50, timeout = 1000) =>
+  new Promise<void>((resolve, reject) => {
+    const startTime = Date.now();
+    const intervalID = setInterval(checkCondition, interval);
+    checkCondition();
+    function checkCondition() {
+      if (condition()) {
+        clearInterval(intervalID);
+        resolve();
+      } else if (Date.now() > startTime + timeout) {
+        clearInterval(intervalID);
+        reject();
+      }
+    }
+  });
+
+describe('EffectsEmitter', () => {
+  let client: ReturnType<typeof Client>;
+  let emitter: ReturnType<typeof EffectsEmitter>;
+
+  beforeEach(() => {
+    client = Client({ game });
+    emitter = EffectsEmitter(client);
+    client.start();
+  });
+
+  describe('#on()', () => {
+    test('effect callbacks are called when a move is made', async () => {
+      const longListener = jest.fn();
+      const shortListener = jest.fn();
+
+      emitter.on('longEffect', longListener);
+      emitter.on('shortEffect', shortListener);
+
+      client.moves.wEffects();
+      await waitFor(() => emitter.size.get() === 0);
+
+      expect(longListener).toHaveBeenCalledTimes(1);
+      expect(longListener).toHaveBeenCalledWith(
+        expect.objectContaining({ payload: '1' })
+      );
+      expect(shortListener).toHaveBeenCalledTimes(1);
+      expect(shortListener).toHaveBeenCalledWith(
+        expect.objectContaining({ payload: '2' })
+      );
+    });
+
+    test('onEnd callbacks are called when a move is made', async () => {
+      const listener = jest.fn();
+      emitter.on('longEffect', () => {}, listener);
+      client.moves.wEffects();
+      await waitFor(() => emitter.size.get() === 0);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    test('an "effects:start" callback is called', async () => {
+      const listener = jest.fn();
+      emitter.on('effects:start', listener);
+      client.moves.simple();
+      await waitFor(() => emitter.size.get() === 0);
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ payload: undefined })
+      );
+    });
+
+    test('an "effects:end" callback is called', async () => {
+      const listener = jest.fn();
+      emitter.on('effects:end', listener);
+      client.moves.simple();
+      await waitFor(() => emitter.size.get() === 0);
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ payload: undefined })
+      );
+    });
+
+    describe('returned unsubscribe function', () => {
+      test('a removed callback is not called', async () => {
+        const listener = jest.fn();
+        const unsub = emitter.on('longEffect', listener);
+        unsub();
+        client.moves.wEffects();
+        await waitFor(() => emitter.size.get() === 0);
+        expect(listener).not.toHaveBeenCalled();
+      });
+
+      test('a removed onEnd callback is not called', async () => {
+        const onStart = () => {};
+        const onEnd = jest.fn();
+        const unsub = emitter.on('longEffect', onStart, onEnd);
+        unsub();
+        client.moves.wEffects();
+        await waitFor(() => emitter.size.get() === 0);
+        expect(onEnd).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('#clear()', () => {
+    test('it prevents any effects from running and empties the queue', async () => {
+      const longListener = jest.fn();
+      emitter.on('longEffect', longListener);
+      client.moves.wEffects();
+      emitter.clear();
+      await waitFor(() => emitter.size.get() === 0);
+      expect(longListener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('#flush()', () => {
+    test('it emits all effects and empties the queue', () => {
+      const listener = jest.fn();
+      emitter.on('effects:start', listener);
+      emitter.on('longEffect', listener);
+      emitter.on('shortEffect', listener);
+      emitter.on('effects:end', listener);
+      client.moves.wEffects();
+      emitter.flush();
+      expect(listener).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe('#size', () => {
+    test('it returns the number of effects in the queue', async () => {
+      await waitFor(() => emitter.size.get() === 0);
+      client.moves.wEffects();
+      expect(emitter.size.get()).toBe(4);
+    });
+
+    test('a subscriber receives the latest queue size', async () => {
+      const listener = jest.fn();
+      emitter.size.subscribe(listener);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenLastCalledWith(2);
+      await waitFor(() => emitter.size.get() === 0);
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenLastCalledWith(0);
+    });
+  });
+
+  describe('internals', () => {
+    test('the raf stops running once all effects are dealt with', async () => {
+      await waitFor(() => emitter.size.get() === 0);
+      expect((emitter as any).raf.running).toBe(false);
+    });
+
+    test('doesn’t throw while boardgame.io is loading state', () => {
+      expect(() => (emitter as any).onUpdate(null)).not.toThrow();
+    });
+
+    test('doesn’t throw if used with a game missing the effects plugin', () => {
+      expect(() => EffectsEmitter(Client({ game: {} }))).not.toThrow();
+    });
+
+    test('only emits effects for a given state update once', async () => {
+      const listener = jest.fn();
+      emitter.on('effects:start', listener);
+      client.moves.simple();
+      await waitFor(() => emitter.size.get() === 0);
+      (emitter as any).onUpdate(client.getState());
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/emitter/emitter.test.ts
+++ b/src/emitter/emitter.test.ts
@@ -89,11 +89,13 @@ describe('EffectsEmitter', () => {
 
       expect(longListener).toHaveBeenCalledTimes(1);
       expect(longListener).toHaveBeenCalledWith(
-        expect.objectContaining({ payload: '1' })
+        '1',
+        expect.objectContaining({ G: { val: GVal.wEffects } })
       );
       expect(shortListener).toHaveBeenCalledTimes(1);
       expect(shortListener).toHaveBeenCalledWith(
-        expect.objectContaining({ payload: '2' })
+        '2',
+        expect.objectContaining({ G: { val: GVal.wEffects } })
       );
     });
 
@@ -111,7 +113,8 @@ describe('EffectsEmitter', () => {
       client.moves.simple();
       await waitFor(() => emitter.size.get() === 0);
       expect(listener).toHaveBeenCalledWith(
-        expect.objectContaining({ payload: undefined })
+        undefined,
+        expect.objectContaining({ G: { val: GVal.simple } })
       );
     });
 
@@ -121,7 +124,8 @@ describe('EffectsEmitter', () => {
       client.moves.simple();
       await waitFor(() => emitter.size.get() === 0);
       expect(listener).toHaveBeenCalledWith(
-        expect.objectContaining({ payload: undefined })
+        undefined,
+        expect.objectContaining({ G: { val: GVal.simple } })
       );
     });
 

--- a/src/emitter/emitter.ts
+++ b/src/emitter/emitter.ts
@@ -132,7 +132,7 @@ class EffectsEmitterImpl<S extends ClientState> implements EffectsEmitter<S> {
     this.emitAllEffects(this.endEmitter, this.activeQueue);
     this.queue.set([]);
     this.activeQueue = [];
-    if (this.state.get() !== this.latestState) this.state.set(this.latestState);
+    this.state.set(this.latestState);
   }
 
   /**

--- a/src/emitter/emitter.ts
+++ b/src/emitter/emitter.ts
@@ -159,6 +159,7 @@ class EffectsEmitterImpl<S extends ClientState> implements EffectsEmitter<S> {
       !prevState.plugins.effects ||
       state.plugins.effects.data.id === prevState.plugins.effects.data.id
     ) {
+      this.state.set(state);
       return;
     }
     this.queue.set(state.plugins.effects.data.queue);

--- a/src/emitter/emitter.ts
+++ b/src/emitter/emitter.ts
@@ -46,6 +46,7 @@ export interface EffectsEmitter<S extends ClientState> {
   clear(): void;
   flush(): void;
   size: ReadonlyStore<number>;
+  state: ReadonlyStore<S | null>;
 }
 
 class EffectsEmitterImpl<S extends ClientState> implements EffectsEmitter<S> {

--- a/src/emitter/emitter.ts
+++ b/src/emitter/emitter.ts
@@ -1,0 +1,209 @@
+import mitt from 'mitt';
+import type { Emitter, Handler, WildcardHandler } from 'mitt';
+import type { Client } from 'boardgame.io/client';
+import type { ClientState } from 'boardgame.io/dist/types/src/client/client';
+import { Store, ComputedStore, ReadonlyStore } from '../store';
+import type { InternalEffectShape, Queue } from '../types';
+import { RafRunner } from './raf-runner';
+
+interface EffectsEmitterOptions {
+  speed?: number;
+  updateStateAfterEffects?: boolean;
+}
+
+type Listener<S extends ClientState> = Handler<
+  InternalEffectShape<Exclude<S, null>>
+>;
+type WildcardListener<S extends ClientState> = WildcardHandler<
+  Record<string, InternalEffectShape<Exclude<S, null>>>
+>;
+
+export interface EffectsEmitter<S extends ClientState> {
+  /**
+   * Register listeners for a specific effect type (or the wildcard effect `'*'`).
+   * @returns An unsubscribe function.
+   */
+  on(
+    effect: '*',
+    callback?: WildcardListener<S>,
+    onEndCallback?: WildcardListener<S>
+  ): () => void;
+  on(
+    effect: Exclude<string, '*'>,
+    callback?: Listener<S>,
+    onEndCallback?: Listener<any>
+  ): () => void;
+  clear(): void;
+  flush(): void;
+  size: ReadonlyStore<number>;
+}
+
+class EffectsEmitterImpl<S extends ClientState> implements EffectsEmitter<S> {
+  private readonly emitter =
+    mitt<Record<string, InternalEffectShape<Exclude<S, null>>>>();
+  private readonly endEmitter =
+    mitt<Record<string, InternalEffectShape<Exclude<S, null>>>>();
+  private readonly raf = new RafRunner(() => this.onRaf());
+  private readonly queue = new Store<Queue>([]);
+  private activeQueue: Queue = [];
+  private latestState: S | null = null;
+  private prevId?: string;
+  private startT = 0;
+  private duration = 0;
+
+  /**
+   * Store for the current boardgame.io client state.
+   */
+  public readonly state = new Store<S | null>(null);
+
+  constructor(
+    private readonly speed: number = 1,
+    private readonly updateStateAfterEffects: boolean = false
+  ) {}
+
+  // TODO: Call callbacks with [payload, state] instead of [{payload, state}]
+  on(
+    effect: '*',
+    callback?: WildcardListener<S>,
+    onEndCallback?: WildcardListener<S>
+  ): () => void;
+  on(
+    effect: Exclude<string, '*'>,
+    callback?: Listener<S>,
+    onEndCallback?: Listener<S>
+  ): () => void;
+  on(
+    effect: string,
+    callback?: Listener<S> | WildcardListener<S>,
+    onEndCallback?: Listener<any> | WildcardListener<S>
+  ): () => void {
+    if (callback) this.emitter.on(effect, callback as Listener<S>);
+    if (onEndCallback) this.endEmitter.on(effect, onEndCallback as Listener<S>);
+    return (): void => this.off(effect, callback, onEndCallback);
+  }
+
+  private off(
+    effect: string,
+    callback?: Listener<S> | WildcardListener<S>,
+    onEndCallback?: Listener<any> | WildcardListener<S>
+  ): void {
+    this.emitter.off(effect, callback as Listener<S>);
+    this.endEmitter.off(effect, onEndCallback as Listener<S>);
+  }
+
+  /**
+   * Callback that clears the effect queue, cancelling future effects and
+   * immediately calling any outstanding onEnd callbacks.
+   */
+  public clear(): void {
+    this.raf.stop();
+    this.emitAllEffects(this.endEmitter, this.activeQueue);
+    this.queue.set([]);
+    this.activeQueue = [];
+    if (this.state.get() !== this.latestState) this.state.set(this.latestState);
+  }
+
+  /**
+   * Callback that immediately emits all remaining effects and clears the queue.
+   * When flushing, onEnd callbacks are run immediately.
+   */
+  public flush(): void {
+    this.emitAllEffects(this.emitter, this.queue.get());
+    this.clear();
+  }
+
+  /** Get the number of effects currently queued to be emitted. */
+  public size = new ComputedStore(this.queue, (queue) => queue.length);
+
+  /**
+   * Update the queue state when a new state update is received from boardgame.io.
+   */
+  public onUpdate(state: null | S): void {
+    if (!state) return;
+    const { effects } = state.plugins;
+    if (!effects) return;
+    if (effects.data.id === this.prevId) return;
+    this.prevId = effects.data.id;
+    this.queue.set(effects.data.queue);
+    this.activeQueue = [];
+    this.startT = performance.now();
+    this.duration = effects.data.duration;
+    this.latestState = state;
+    this.raf.start();
+  }
+
+  /**
+   * requestAnimationFrame loop which dispatches effects and updates the queue
+   * every tick while active.
+   */
+  private onRaf(): void {
+    const elapsedT = ((performance.now() - this.startT) / 1000) * this.speed;
+    const newActiveQueue: Queue = [];
+    // Loop through the queue of active effects.
+    let ended = false;
+    for (const effect of this.activeQueue) {
+      if (effect.endT > elapsedT) {
+        newActiveQueue.push(effect);
+        continue;
+      }
+      this.emit(this.endEmitter, effect);
+      ended = true;
+    }
+    // Loop through the effects queue, emitting any effects whose time has come.
+    const queue = this.queue.get();
+    let i = 0;
+    for (i = 0; i < queue.length; i++) {
+      const effect = queue[i];
+      if (effect.t > elapsedT) break;
+      this.emit(this.emitter, effect);
+      newActiveQueue.push(effect);
+    }
+    // Also update the global boardgame.io props once their time is reached.
+    const bgioStateT = this.updateStateAfterEffects ? this.duration : 0;
+    if (elapsedT >= bgioStateT && this.state.get() !== this.latestState)
+      this.state.set(this.latestState);
+    if (elapsedT > this.duration) this.raf.stop();
+    // Update the queue to only contain effects still in the future.
+    if (i > 0) this.queue.set(queue.slice(i));
+    if (i > 0 || ended) this.activeQueue = newActiveQueue;
+  }
+
+  /**
+   * Emit an effect from the provided emitter, bundling payload and boardProps
+   * into the effect object.
+   */
+  private emit(emitter: Emitter<any>, { type, payload }: Queue[number]) {
+    const effect: InternalEffectShape = {
+      payload,
+      boardProps: this.latestState!,
+    };
+    emitter.emit(type, effect);
+  }
+
+  /**
+   * Dispatch all effects in the provided queue via the provided emitter.
+   * @param emitter - Mitt instance.
+   * @param effects - Effects queue to process.
+   */
+  private emitAllEffects(emitter: Emitter<any>, effects: Readonly<Queue>) {
+    for (const effect of effects) {
+      this.emit(emitter, effect);
+    }
+  }
+}
+
+export function InternalEffectsEmitter<S extends ClientState>({
+  speed,
+  updateStateAfterEffects,
+}: EffectsEmitterOptions = {}): EffectsEmitterImpl<S> {
+  return new EffectsEmitterImpl<S>(speed, updateStateAfterEffects);
+}
+
+export function EffectsEmitter(
+  client: { subscribe: ReturnType<typeof Client>['subscribe'] },
+  opts?: EffectsEmitterOptions
+): EffectsEmitter<ClientState> {
+  const emitter = InternalEffectsEmitter(opts);
+  client.subscribe(emitter.onUpdate.bind(emitter));
+  return emitter;
+}

--- a/src/emitter/index.ts
+++ b/src/emitter/index.ts
@@ -1,0 +1,1 @@
+export { EffectsEmitter } from './emitter';

--- a/src/emitter/raf-runner.test.ts
+++ b/src/emitter/raf-runner.test.ts
@@ -1,0 +1,48 @@
+import { RafRunner } from './raf-runner';
+
+jest.useFakeTimers();
+
+describe('RafRunner', () => {
+  it('should start and stop', () => {
+    const callback = jest.fn();
+    const runner = new RafRunner(callback);
+    expect((runner as any).running).toBe(false);
+    runner.start();
+    expect((runner as any).running).toBe(true);
+    runner.stop();
+    expect((runner as any).running).toBe(false);
+    jest.runAllTimers();
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should call the callback', () => {
+    const callback = jest.fn();
+    const runner = new RafRunner(callback);
+    runner.start();
+    jest.runOnlyPendingTimers();
+    expect(callback).toHaveBeenCalledTimes(1);
+    runner.stop();
+  });
+
+  it('should call the callback multiple times', () => {
+    const callback = jest.fn();
+    const runner = new RafRunner(callback);
+    runner.start();
+    jest.runOnlyPendingTimers();
+    expect(callback).toHaveBeenCalledTimes(1);
+    jest.runOnlyPendingTimers();
+    expect(callback).toHaveBeenCalledTimes(2);
+    runner.stop();
+  });
+
+  it('should not queue more tasks if start is called repeatedly', () => {
+    const callback = jest.fn();
+    const runner = new RafRunner(callback);
+    runner.start();
+    runner.start();
+    runner.start();
+    jest.runOnlyPendingTimers();
+    expect(callback).toHaveBeenCalledTimes(1);
+    runner.stop();
+  });
+});

--- a/src/emitter/raf-runner.ts
+++ b/src/emitter/raf-runner.ts
@@ -1,0 +1,22 @@
+/** Manage starting and stopping a `requestAnimationFrame` loop. */
+export class RafRunner {
+  private running = false;
+  private raf?: number;
+  constructor(private readonly callback: () => void) {}
+
+  public start(): void {
+    if (this.running) return;
+    const frameCallback = () => {
+      if (!this.running) return;
+      this.callback();
+      this.raf = requestAnimationFrame(frameCallback);
+    };
+    this.running = true;
+    this.raf = requestAnimationFrame(frameCallback);
+  }
+
+  public stop(): void {
+    this.running = false;
+    if (this.raf) cancelAnimationFrame(this.raf);
+  }
+}

--- a/src/react/components.tsx
+++ b/src/react/components.tsx
@@ -1,16 +1,13 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
-import useRafLoop from 'react-use/lib/useRafLoop';
-import useUpdate from 'react-use/lib/useUpdate';
-import mitt from 'mitt';
-import type { Emitter } from 'mitt';
+import React, { useCallback, useEffect, useState } from 'react';
 import type { BoardProps } from 'boardgame.io/react';
-import type { Data, Queue } from '../types';
-import type { InternalEffectShape } from './types';
 import {
   EffectsContext,
   EffectsPropsContext,
   EffectsQueueContext,
 } from './contexts';
+import { InternalEffectsEmitter } from '../emitter/emitter';
+import type { QueueAPI } from './types';
+import { useStore } from './hooks/useStore';
 
 /**
  * Configuration options that can be passed to EffectsBoardWrapper.
@@ -41,189 +38,58 @@ export function EffectsBoardWrapper<
 }
 
 /**
- * Hook very similar to `useState` except that state is stored in a ref.
- * This allows the requestAnimationFrame loop to access the latest state
- * before React rerenders, but also update React as `setState` would usually.
- */
-function useRefState<T>(initial: T) {
-  const state = useRef(initial);
-  const rerender = useUpdate();
-  const setState = useCallback(
-    (newState: T) => {
-      state.current = newState;
-      rerender();
-    },
-    [state, rerender]
-  );
-  return [state, setState] as const;
-}
-
-/**
- * Emit an effect from the provided emitter, bundling payload and boardProps
- * into the effect object.
- */
-function emit(
-  emitter: Emitter<any>,
-  { type, payload }: Queue[number],
-  boardProps: BoardProps
-) {
-  const effect: InternalEffectShape = { payload, boardProps };
-  emitter.emit(type, effect);
-}
-
-/**
- * Dispatch all effects in the provided queue via the provided emitter.
- * @param emitter - Mitt instance.
- * @param effects - React ref for the effects queue to process.
- */
-function emitAllEffects(
-  emitter: Emitter<any>,
-  effects: React.MutableRefObject<Queue>,
-  boardProps: BoardProps
-) {
-  for (const effect of effects.current) {
-    emit(emitter, effect, boardProps);
-  }
-}
-
-/**
  * Context provider that watches boardgame.io state and emits effect events.
  */
 function EffectsProvider<G = any, P extends BoardProps<G> = BoardProps<G>>({
   Board,
   boardProps,
-  opts: { speed = 1, updateStateAfterEffects = false } = {},
+  opts,
 }: {
   Board: React.ComponentType<P>;
   boardProps: P;
   opts?: EffectsOpts;
 }) {
-  const { effects } = boardProps.plugins as { effects?: { data: Data } };
-  const id = effects && effects.data.id;
-  const duration = (effects && effects.data.duration) || 0;
-  const bgioStateT: number = updateStateAfterEffects ? duration : 0;
-  const [prevId, setPrevId] = useState<string | undefined>(id);
-  const [emitter] = useState(() => mitt());
-  const [endEmitter] = useState(() => mitt());
-  const [startT, setStartT] = useState(0);
-  const [bgioProps, setBgioProps] = useState(boardProps);
-  const [queue, setQueue] = useRefState<Queue>([]);
-  const [activeQueue, setActiveQueue] = useRefState<Queue>([]);
+  const [emitter] = useState(() => {
+    const emitter = InternalEffectsEmitter<BoardProps>(opts);
+    emitter.onUpdate(boardProps);
+    return emitter;
+  });
+  // When props change, let the emitter handle the update.
+  useEffect(() => emitter.onUpdate(boardProps), [boardProps, emitter]);
 
-  /**
-   * requestAnimationFrame loop which dispatches effects and updates the queue
-   * every tick while active.
-   */
-  const [stopRaf, startRaf, isRafActive] = useRafLoop(() => {
-    const elapsedT = ((performance.now() - startT) / 1000) * speed;
-    const newActiveQueue: Queue = [];
-    // Loop through the queue of active effects.
-    let ended = false;
-    for (let i = 0; i < activeQueue.current.length; i++) {
-      const effect = activeQueue.current[i];
-      if (effect.endT > elapsedT) {
-        newActiveQueue.push(effect);
-        continue;
-      }
-      emit(endEmitter, effect, boardProps);
-      ended = true;
-    }
-    // Loop through the effects queue, emitting any effects whose time has come.
-    let i = 0;
-    for (i = 0; i < queue.current.length; i++) {
-      const effect = queue.current[i];
-      if (effect.t > elapsedT) break;
-      emit(emitter, effect, boardProps);
-      newActiveQueue.push(effect);
-    }
-    // Also update the global boardgame.io props once their time is reached.
-    if (elapsedT >= bgioStateT && boardProps !== bgioProps)
-      setBgioProps(boardProps);
-    if (elapsedT > duration) stopRaf();
-    // Update the queue to only contain effects still in the future.
-    if (i > 0) setQueue(queue.current.slice(i));
-    if (i > 0 || ended) setActiveQueue(newActiveQueue);
-  }, false);
+  /** Public API for manipulating the EffectsEmitter queue. */
+  const queueAPI: QueueAPI = {
+    /**
+     * Callback that clears the effect queue, cancelling future effects and
+     * immediately calling any outstanding onEnd callbacks.
+     */
+    clear: useCallback(() => emitter.clear(), [emitter]),
+    /**
+     * Callback that immediately emits all remaining effects and clears the queue.
+     * When flushing, onEnd callbacks are run immediately.
+     */
+    flush: useCallback(() => emitter.flush(), [emitter]),
+    /**
+     * Callback that immediately updates the props to the latest props received.
+     */
+    update: useCallback(() => {
+      emitter.state.set(boardProps);
+    }, [emitter.state, boardProps]),
+    /**
+     * The number of effects currently in the queue.
+     */
+    size: useStore(emitter.size),
+  };
 
-  /**
-   * Update the queue state when a new update is received from boardgame.io.
-   */
-  useEffect(() => {
-    if (!effects || id === prevId) {
-      // If some non-game state props change, or the effects plugin is not
-      // enabled, still update boardgame.io props for the board component.
-      if (
-        (!updateStateAfterEffects || !isRafActive()) &&
-        boardProps !== bgioProps
-      ) {
-        setBgioProps(boardProps);
-      }
-      return;
-    }
-    setPrevId(effects.data.id);
-    setQueue(effects.data.queue);
-    emitAllEffects(endEmitter, activeQueue, boardProps);
-    setActiveQueue([]);
-    setStartT(performance.now());
-    startRaf();
-  }, [
-    effects,
-    id,
-    prevId,
-    updateStateAfterEffects,
-    isRafActive,
-    boardProps,
-    bgioProps,
-    setQueue,
-    endEmitter,
-    activeQueue,
-    setActiveQueue,
-    startRaf,
-  ]);
-
-  /**
-   * Callback that clears the effect queue, cancelling future effects and
-   * immediately calling any outstanding onEnd callbacks.
-   */
-  const clear = useCallback(() => {
-    stopRaf();
-    emitAllEffects(endEmitter, activeQueue, boardProps);
-    setActiveQueue([]);
-    setQueue([]);
-    if (boardProps !== bgioProps) setBgioProps(boardProps);
-  }, [
-    stopRaf,
-    endEmitter,
-    activeQueue,
-    setActiveQueue,
-    setQueue,
-    boardProps,
-    bgioProps,
-  ]);
-
-  /**
-   * Callback that immediately emits all remaining effects and clears the queue.
-   * When flushing, onEnd callbacks are run immediately.
-   */
-  const flush = useCallback(() => {
-    emitAllEffects(emitter, queue, boardProps);
-    clear();
-  }, [emitter, queue, clear, boardProps]);
-
-  /**
-   * Callback that updates the props to the latest props received
-   */
-  const update = useCallback(() => {
-    if (boardProps !== bgioProps) setBgioProps(boardProps);
-  }, [boardProps, bgioProps]);
+  // Subscribe to the emitter's state and use it as the source of the board’s props.
+  const bgioProps = useStore(emitter.state);
+  const props = opts?.updateStateAfterEffects ? bgioProps! : boardProps;
 
   return (
-    <EffectsContext.Provider value={{ emitter, endEmitter }}>
-      <EffectsQueueContext.Provider
-        value={{ clear, flush, update, size: queue.current.length }}
-      >
-        <EffectsPropsContext.Provider value={bgioProps}>
-          <Board {...(bgioProps as P)} />
+    <EffectsContext.Provider value={emitter}>
+      <EffectsQueueContext.Provider value={queueAPI}>
+        <EffectsPropsContext.Provider value={props}>
+          <Board {...(props as P)} />
         </EffectsPropsContext.Provider>
       </EffectsQueueContext.Provider>
     </EffectsContext.Provider>

--- a/src/react/contexts.ts
+++ b/src/react/contexts.ts
@@ -1,12 +1,11 @@
 import { createContext } from 'react';
-import type { Emitter } from 'mitt';
 import type { BoardProps } from 'boardgame.io/react';
-import { QueueAPI } from './types';
+import type { QueueAPI } from './types';
+import type { EffectsEmitter } from '../emitter';
 
-export const EffectsContext = createContext<{
-  emitter: Emitter<any> | null;
-  endEmitter: Emitter<any> | null;
-}>({ emitter: null, endEmitter: null });
+export const EffectsContext = createContext<EffectsEmitter<BoardProps> | null>(
+  null
+);
 
 export const EffectsQueueContext = createContext<QueueAPI | undefined>(
   undefined

--- a/src/react/hooks/useStore.ts
+++ b/src/react/hooks/useStore.ts
@@ -1,0 +1,9 @@
+import { useEffect, useState } from 'react';
+import type { Store } from '../../store';
+
+/** Hook that returns the current value of a store and keeps it updated. */
+export function useStore<Value>(store: Store<Value>): Readonly<Value> {
+  const [state, setState] = useState(store.get());
+  useEffect(() => store.subscribe(setState), [store]);
+  return state;
+}

--- a/src/react/index.test.tsx
+++ b/src/react/index.test.tsx
@@ -440,6 +440,61 @@ describe('useEffectListener', () => {
     expect(mock).toHaveBeenLastCalledWith('2', ListenerState.OnEnd);
   });
 
+  test('onEnd callback can return a clean-up callback', async () => {
+    enum ListenerState {
+      'Initial' = 1,
+      'OnEffect',
+      'AfterEffect',
+    }
+    const clear = jest.fn((to: NodeJS.Timeout) => clearTimeout(to));
+    const ComponentWithEffects = () => {
+      const [state, setState] = useState(ListenerState.Initial);
+      useEffectListener<typeof config>(
+        'shortEffect',
+        () => {},
+        [],
+        () => {
+          setState(ListenerState.OnEffect);
+          const to = setTimeout(() => {
+            setState(ListenerState.AfterEffect);
+          }, 150);
+          return () => clear(to);
+        },
+        []
+      );
+      return <p data-testid="CWE">{state}</p>;
+    };
+    const App = Client<G>({
+      game: game as unknown as Game<G>,
+      debug: false,
+      board: EffectsBoardWrapper(({ G, moves }: BoardProps<G>) => (
+        <main>
+          {(!G.val || G.val === GVal.repeatEffects) && <ComponentWithEffects />}
+          <p data-testid="G-val">{G.val}</p>
+          <button onClick={() => moves.simple()}>Simple Move</button>
+          <button onClick={() => moves.repeatEffects()}>Repeat Effects</button>
+        </main>
+      )),
+    });
+
+    render(<App />);
+    expect(screen.getByTestId('CWE')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Repeat Effects'));
+    await waitFor(() => screen.getByText(GVal.repeatEffects));
+    await waitFor(() => screen.getByText(ListenerState.OnEffect));
+    expect(clear).toHaveBeenCalledTimes(0);
+    await waitFor(() => screen.getByText(ListenerState.AfterEffect));
+    // Called once when cleanup executed for repeated effect.
+    expect(clear).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByText('Simple Move'));
+    await waitFor(() => screen.getByText(GVal.simple));
+    expect(screen.queryByTestId('CWE')).not.toBeInTheDocument();
+    // Called again on component unmount.
+    expect(clear).toHaveBeenCalledTimes(2);
+  });
+
   test('throws if used outside of EffectsBoardWrapper', () => {
     const App = () => {
       useEffectListener('*', () => {}, []);

--- a/src/react/types.ts
+++ b/src/react/types.ts
@@ -1,6 +1,6 @@
 import type { O } from 'ts-toolbelt';
 import type { BoardProps } from 'boardgame.io/react';
-import {
+import type {
   BuiltinEffect,
   EffectsMap,
   EffectWithCreate,
@@ -24,19 +24,13 @@ export interface QueueAPI {
 type CbReturn = void | (() => void);
 
 /**
- * Context object passed to all callbacks in addition to the effect payload.
- * Currently this is the entire board props object, containing G etc.
- */
-type EffectCbContext<G> = BoardProps<G>;
-
-/**
  * Type of callback when listening for all effects with '*'.
  */
 type AllEffectsCb<E extends EffectsMap, G> = (
   ...cbArgs: O.UnionOf<{
     [K in keyof E]: E[K] extends EffectWithCreate
-      ? [K, EffectPayload<E[K]>, EffectCbContext<G>]
-      : [K, undefined, EffectCbContext<G>];
+      ? [K, EffectPayload<E[K]>, BoardProps<G>]
+      : [K, undefined, BoardProps<G>];
   }>
 ) => CbReturn;
 
@@ -48,8 +42,8 @@ type EffectCb<
   K extends keyof E,
   G
 > = E[K] extends EffectWithCreate
-  ? (payload: EffectPayload<E[K]>, context: EffectCbContext<G>) => CbReturn
-  : (payload: undefined, context: EffectCbContext<G>) => CbReturn;
+  ? (payload: EffectPayload<E[K]>, context: BoardProps<G>) => CbReturn
+  : (payload: undefined, context: BoardProps<G>) => CbReturn;
 
 export type ListenerArgs<E extends EffectsMap, G> =
   | ['*', AllEffectsCb<E, G>, React.DependencyList]
@@ -72,12 +66,3 @@ export type ListenerArgs<E extends EffectsMap, G> =
           ];
     }>
   | [BuiltinEffect, () => CbReturn, React.DependencyList];
-
-/**
- * Shape of the effect objects emitted internally through mitt.
- * This is then destructured to pass to the effect listener.
- */
-export interface InternalEffectShape {
-  payload: any;
-  boardProps: EffectCbContext<any>;
-}

--- a/src/store/computed.test.ts
+++ b/src/store/computed.test.ts
@@ -1,0 +1,65 @@
+import { Store, ComputedStore } from '.';
+
+let unsubscribe: () => void;
+beforeEach(() => {
+  unsubscribe = () => {};
+});
+afterEach(() => {
+  unsubscribe();
+});
+
+describe('ComputedStore', () => {
+  test('construction', () => {
+    const store = new Store(1);
+    const computed = new ComputedStore(store, (value) => value + 1);
+    expect(computed.get()).toBe(2);
+  });
+
+  describe('#subscribe', () => {
+    test('callback is called when the value changes', () => {
+      const store = new Store(1);
+      const computed = new ComputedStore(store, (value) => value + 1);
+      const listener = jest.fn();
+      unsubscribe = computed.subscribe(listener);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenLastCalledWith(2);
+      store.set(2);
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenLastCalledWith(3);
+    });
+
+    test('calls all subscribed callbacks', () => {
+      const store = new Store(1);
+      const computed = new ComputedStore(store, (value) => value + 1);
+      const listener1 = jest.fn();
+      const listener2 = jest.fn();
+      const unsub1 = computed.subscribe(listener1);
+      const unsub2 = computed.subscribe(listener2);
+      unsubscribe = () => {
+        unsub1();
+        unsub2();
+      };
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener1).toHaveBeenLastCalledWith(2);
+      expect(listener2).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenLastCalledWith(2);
+      store.set(2);
+      expect(listener1).toHaveBeenCalledTimes(2);
+      expect(listener1).toHaveBeenLastCalledWith(3);
+      expect(listener2).toHaveBeenCalledTimes(2);
+      expect(listener2).toHaveBeenLastCalledWith(3);
+    });
+
+    test('returns an unsubscribe method that stops callback being called again', () => {
+      const store = new Store(1);
+      const computed = new ComputedStore(store, (value) => value + 1);
+      const listener = jest.fn();
+      unsubscribe = computed.subscribe(listener);
+      store.set(2);
+      unsubscribe();
+      store.set(3);
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenLastCalledWith(3);
+    });
+  });
+});

--- a/src/store/computed.ts
+++ b/src/store/computed.ts
@@ -1,0 +1,53 @@
+import { Handler } from 'mitt';
+import { Store } from './store';
+
+/** Store whose value is derived from that of another `Store` */
+export class ComputedStore<ComputedValue, Value> extends Store<ComputedValue> {
+  private unsubscribe?: () => void;
+
+  constructor(
+    private readonly store: Store<Value>,
+    private readonly selector: (value: Readonly<Value>) => ComputedValue
+  ) {
+    // Initialise stored value using current parent store value.
+    super(selector(store.get()));
+  }
+
+  /** Initiate subscription to parent store if necessary. */
+  private start(): void {
+    if (this.unsubscribe) return;
+    this.unsubscribe = this.store.subscribe((value) => {
+      this.set(this.selector(value));
+    });
+  }
+
+  /** Unsubscribe from parent store if no-one is subscribed to computed state. */
+  private stop(): void {
+    if (!this.unsubscribe || this.hasSubscribers) return;
+    this.unsubscribe();
+    delete this.unsubscribe;
+  }
+
+  /**
+   * Subscribe to updates of the stored value.
+   * @returns An unsubscribe function.
+   */
+  subscribe(handler: Handler<Readonly<ComputedValue>>): () => void {
+    this.start();
+    const unsubscribe = super.subscribe(handler);
+    return () => {
+      unsubscribe();
+      this.stop();
+    };
+  }
+
+  /** Get the currently stored value. */
+  get(): Readonly<ComputedValue> {
+    // Compute the current value on demand. This could be inefficient if the
+    // selector were expensive, but that’s not the case for our usage.
+    return this.selector(this.store.get());
+  }
+}
+
+/** Value store. `subscribe` for updates, or `get` the current value. */
+export type ReadonlyStore<Value> = Omit<Store<Value>, 'set'>;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,0 +1,3 @@
+export { Store } from './store';
+export { ComputedStore } from './computed';
+export type { ReadonlyStore } from './computed';

--- a/src/store/store.test.ts
+++ b/src/store/store.test.ts
@@ -1,0 +1,65 @@
+import { Store } from '.';
+
+let unsubscribe: () => void;
+beforeEach(() => {
+  unsubscribe = () => {};
+});
+afterEach(() => {
+  unsubscribe();
+});
+
+describe('Store', () => {
+  test('construction', () => {
+    const store = new Store(1);
+    expect(store.get()).toBe(1);
+  });
+
+  describe('#subscribe', () => {
+    test('callback is called when the value changes', () => {
+      const store = new Store(1);
+      const listener = jest.fn();
+      unsubscribe = store.subscribe(listener);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenLastCalledWith(1);
+      store.set(2);
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenLastCalledWith(2);
+    });
+
+    test('returns an unsubscribe method that stops callback being called again', () => {
+      const store = new Store(1);
+      const listener = jest.fn();
+      unsubscribe = store.subscribe(listener);
+      store.set(2);
+      unsubscribe();
+      store.set(3);
+      expect(listener).toHaveBeenCalledTimes(2);
+      expect(listener).toHaveBeenLastCalledWith(2);
+    });
+  });
+
+  describe('#set', () => {
+    test('updates value', () => {
+      const store = new Store(1);
+      expect(store.get()).toBe(1);
+      store.set(2);
+      expect(store.get()).toBe(2);
+    });
+
+    test('doesn’t notify subscribers if value hasn’t changed', () => {
+      const store = new Store(1);
+      const listener = jest.fn();
+      unsubscribe = store.subscribe(listener);
+      store.set(1);
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener).toHaveBeenLastCalledWith(1);
+    });
+  });
+
+  describe('#get', () => {
+    test('returns current value', () => {
+      const store = new Store(1);
+      expect(store.get()).toBe(1);
+    });
+  });
+});

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,0 +1,36 @@
+import mitt from 'mitt';
+import { Handler } from 'mitt';
+
+/** Simple value store with subscribe method to listen for changes. */
+export class Store<Value> {
+  private static readonly Event = 'change';
+  private readonly mitt = mitt<Record<typeof Store.Event, Readonly<Value>>>();
+  constructor(private value: Value) {}
+
+  protected get hasSubscribers(): boolean {
+    const subscribers = this.mitt.all.get(Store.Event);
+    return subscribers !== undefined && subscribers.length > 0;
+  }
+
+  /**
+   * Subscribe to updates of the store value.
+   * @returns An unsubscribe function.
+   */
+  subscribe(handler: Handler<Readonly<Value>>): () => void {
+    this.mitt.on(Store.Event, handler);
+    handler(this.value);
+    return () => this.mitt.off(Store.Event, handler);
+  }
+
+  /** Update the stored value, notifying all subscribers if it changed. */
+  set(value: Value): void {
+    if (this.value === value) return;
+    this.value = value;
+    this.mitt.emit(Store.Event, value);
+  }
+
+  /** Get the currently stored value. */
+  get(): Readonly<Value> {
+    return this.value;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { ClientState } from 'boardgame.io/dist/types/src/client/client';
 import type { F, O, U } from 'ts-toolbelt';
 import type { Timeline } from './timeline';
 
@@ -132,3 +133,20 @@ export type API<E extends EffectsMap> = {
 export type EffectsCtxMixin<C extends EffectsPluginConfig> = {
   effects: API<C['effects']>;
 };
+
+/**
+ * Context object passed to all callbacks in addition to the effect payload.
+ * Currently this is the entire board props object, containing G etc.
+ */
+export type EffectCbContext<G> = Exclude<ClientState<G>, null>;
+
+/**
+ * Shape of the effect objects emitted internally through mitt.
+ * This is then destructured to pass to the effect listener.
+ */
+export interface InternalEffectShape<
+  S extends EffectCbContext<any> = EffectCbContext<any>
+> {
+  payload: any;
+  boardProps: S;
+}


### PR DESCRIPTION
Closes #148

This PR extracts all the logic responsible for processing boardgame.io state updates and emitting effects from the React component to a plain JavaScript class.

Doing so helps clarify some logic, makes it possible to use the effects emitter with a plain JS boardgame.io client, and also looks like it has some small performance benefits at least in terms of a reduced number of React renders (based on some simple profiling with [the existing demo](https://codesandbox.io/s/bgio-effects-demo-3nzwm)).

BREAKING CHANGE: The public API for the existing packages has not changed and should continue to work as previously. The React unit tests remain unchanged. However, because this is such a thorough rewrite, there may be small differences that turn out to be breaking in subtle edge cases.

We are also now using an internal type that was added in boardgame.io@0.42.0, so no longer support 0.39.16, ^0.40 and ^0.41.